### PR TITLE
Implement listen states

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -55,13 +55,15 @@ SRC = \
   nci_sm.c \
   nci_state.c \
   nci_state_discovery.c \
+  nci_state_listen_active.c \
+  nci_state_listen_sleep.c \
   nci_state_poll_active.c \
   nci_state_w4_all_discoveries.c \
   nci_state_w4_host_select.c \
   nci_transition.c \
+  nci_transition_deactivate_to_discovery.c \
   nci_transition_deactivate_to_idle.c \
   nci_transition_idle_to_discovery.c \
-  nci_transition_poll_active_to_discovery.c \
   nci_transition_poll_active_to_idle.c \
   nci_transition_reset.c \
   nci_util.c

--- a/README
+++ b/README
@@ -1,13 +1,15 @@
-NFC NCI state machine implementatiton
-=====================================
+NFC NCI state machine implementation
+====================================
 
-The following states are implemented according to NCI 1.0 spec:
+Implements all the states defined in NCI 1.0 spec:
 
   RFST_IDLE
   RFST_DISCOVERY
   RFST_W4_ALL_DISCOVERIES
   RFST_W4_HOST_SELECT
   RFST_POLL_ACTIVE
+  RFST_LISTEN_ACTIVE
+  RFST_LISTEN_SLEEP
 
 as well as a limited subset of NCI 2.0 features.
 

--- a/include/nci_core.h
+++ b/include/nci_core.h
@@ -1,6 +1,6 @@
 /*
- * Copyright (C) 2018-2019 Jolla Ltd.
- * Copyright (C) 2018-2019 Slava Monich <slava.monich@jolla.com>
+ * Copyright (C) 2018-2020 Jolla Ltd.
+ * Copyright (C) 2018-2020 Slava Monich <slava.monich@jolla.com>
  *
  * You may use this file under the terms of BSD license as follows:
  *
@@ -93,6 +93,11 @@ void
 nci_core_set_state(
     NciCore* nci,
     NCI_STATE state);
+
+void
+nci_core_set_op_mode(
+    NciCore* nci,
+    NCI_OP_MODE op_mode); /* Since 1.1.0 */
 
 guint
 nci_core_send_data_msg(

--- a/include/nci_types.h
+++ b/include/nci_types.h
@@ -226,6 +226,37 @@ typedef enum nci_state_id {
     NCI_CORE_STATES
 } NCI_STATE;
 
+/*
+ * Operation modes
+ *
+ * The relationship between op mode bits goes like this:
+ *
+ * +----------------+---------------------+----------------+
+ * | NFC R/W Modes  |   NFC Peer Modes    | NFC CE Mode    |
+ * | NFC_OP_MODE_RW |   NFC_OP_MODE_PEER  | NFC_OP_MODE_CE |
+ * +------+---------+-----------+---------+----------------+
+ * | Tags | ISO-DEP | NFC-DEP   | NFC-DEP | ISO-DEP        |
+ * | 1-3  |         | Initiator | Target  |                |
+ * +------+---------+-----------+---------+----------------+
+ * |      Poll side             |     Listen side          |
+ * |      NFC_OP_MODE_POLL      |     NFC_OP_MODE_LISTEN   |
+ * +----------------------------+--------------------------+
+ *
+ * That hopefully explains why certain combinations don't make
+ * sense, specifically (NFC_OP_MODE_RW | NFC_OP_MODE_LISTEN)
+ * and (NFC_OP_MODE_CE | NFC_OP_MODE_POLL).
+ */
+
+typedef enum nci_op_mode {
+    NFC_OP_MODE_NONE = 0x00,
+    NFC_OP_MODE_RW = 0x01,      /* Reader/Writer (requires POLL) */
+    NFC_OP_MODE_PEER = 0x02,    /* Peer NFC-DEP (POLL and/or LISTEN) */
+    NFC_OP_MODE_CE = 0x04,      /* Card Emulation (requires LISTEN) */
+    /* The next two are kind of orthogonal, see the diagram above */
+    NFC_OP_MODE_POLL = 0x08,    /* Poll side/Initiator */
+    NFC_OP_MODE_LISTEN = 0x10   /* Listen side/Target */
+} NCI_OP_MODE; /* Since 1.1.0 */
+
 /* Logging */
 
 #define NCI_LOG_MODULE nci_log

--- a/src/nci_core.c
+++ b/src/nci_core.c
@@ -1,6 +1,6 @@
 /*
- * Copyright (C) 2018-2019 Jolla Ltd.
- * Copyright (C) 2018-2019 Slava Monich <slava.monich@jolla.com>
+ * Copyright (C) 2018-2020 Jolla Ltd.
+ * Copyright (C) 2018-2020 Slava Monich <slava.monich@jolla.com>
  *
  * You may use this file under the terms of BSD license as follows:
  *
@@ -537,6 +537,18 @@ nci_core_set_state(
 
     if (G_LIKELY(self)) {
         nci_sm_switch_to(self->sm, state);
+    }
+}
+
+void
+nci_core_set_op_mode(
+    NciCore* core,
+    NCI_OP_MODE op_mode) /* Since 1.1.0 */
+{
+    NciCoreObject* self = nci_core_object(core);
+
+    if (G_LIKELY(self)) {
+        nci_sm_set_op_mode(self->sm, op_mode);
     }
 }
 

--- a/src/nci_sm.h
+++ b/src/nci_sm.h
@@ -256,6 +256,7 @@ struct nci_sm {
     NCI_NFCC_DISCOVERY nfcc_discovery;
     NCI_NFCC_ROUTING nfcc_routing;
     NCI_NFCC_POWER nfcc_power;
+    NCI_OP_MODE op_mode;
 };
 
 typedef
@@ -302,6 +303,12 @@ nci_sm_new(
 void
 nci_sm_free(
     NciSm* sm)
+    NCI_INTERNAL;
+
+void
+nci_sm_set_op_mode(
+    NciSm* sm,
+    NCI_OP_MODE op_mode)
     NCI_INTERNAL;
 
 void

--- a/src/nci_state.h
+++ b/src/nci_state.h
@@ -126,6 +126,16 @@ nci_state_discovery_new(
     NciSm* sm)
     NCI_INTERNAL;
 
+NciState* /* NCI_RFST_LISTEN_ACTIVE */
+nci_state_listen_active_new(
+    NciSm* sm)
+    NCI_INTERNAL;
+
+NciState* /* NCI_RFST_LISTEN_SLEEP */
+nci_state_listen_sleep_new(
+    NciSm* sm)
+    NCI_INTERNAL;
+
 NciState* /* NCI_RFST_POLL_ACTIVE */
 nci_state_poll_active_new(
     NciSm* sm)

--- a/src/nci_state_listen_active.c
+++ b/src/nci_state_listen_active.c
@@ -1,0 +1,215 @@
+/*
+ * Copyright (C) 2020 Jolla Ltd.
+ * Copyright (C) 2020 Slava Monich <slava.monich@jolla.com>
+ *
+ * You may use this file under the terms of BSD license as follows:
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *   1. Redistributions of source code must retain the above copyright
+ *      notice, this list of conditions and the following disclaimer.
+ *   2. Redistributions in binary form must reproduce the above copyright
+ *      notice, this list of conditions and the following disclaimer in the
+ *      documentation and/or other materials provided with the distribution.
+ *   3. Neither the names of the copyright holders nor the names of its
+ *      contributors may be used to endorse or promote products derived
+ *      from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "nci_sm.h"
+#include "nci_state_impl.h"
+#include "nci_log.h"
+
+typedef NciState NciStateListenActive;
+typedef NciStateClass NciStateListenActiveClass;
+
+GType nci_state_listen_active_get_type(void) NCI_INTERNAL;
+#define THIS_TYPE (nci_state_listen_active_get_type())
+#define PARENT_CLASS (nci_state_listen_active_parent_class)
+
+G_DEFINE_TYPE(NciStateListenActive, nci_state_listen_active, NCI_TYPE_STATE)
+
+/*==========================================================================*
+ * Implementation
+ *==========================================================================*/
+
+static
+gboolean
+nci_state_listen_active_interface_error_ntf(
+    NciState* self,
+    const GUtilData* payload)
+{
+    const guint8* pkt = payload->bytes;
+    const guint len = payload->size;
+
+    /*
+     * Table 19: Control Messages for Interface Error
+     *
+     * CORE_INTERFACE_ERROR_NTF
+     *
+     * +=========================================================+
+     * | Offset | Size | Description                             |
+     * +=========================================================+
+     * | 0      | 1    | Status                                  |
+     * | 1      | 1    | Conn ID                                 |
+     * +=========================================================+
+     *
+     * 5.2.6 State RFST_LISTEN_ACTIVE
+     *
+     * ...
+     * When using the ISO-DEP or NFC-DEP RF interface, and the NFCC
+     * detects an error during the RF communication, which does not
+     * require returning to the IDLE state, as defined in the Listen
+     * Mode state machine, the NFCC SHALL send CORE_INTERFACE_ERROR_NTF,
+     * using the appropriate status out of RF_TRANSMISSION_ERROR,
+     * RF_PROTOCOL_ERROR and RF_TIMEOUT_ERROR. The state will then
+     * remain RFST_LISTEN_ACTIVE.
+     */
+    if (len == 2) {
+        NciSm* sm = nci_state_sm(self);
+
+        switch (pkt[0]) {
+        case NCI_RF_TRANSMISSION_ERROR:
+            GDEBUG("CORE_INTERFACE_ERROR_NTF (Transmission Error)");
+            nci_sm_switch_to(sm, NCI_RFST_DISCOVERY);
+            return TRUE;
+        case NCI_RF_PROTOCOL_ERROR:
+            GDEBUG("CORE_INTERFACE_ERROR_NTF (Protocol Error)");
+            nci_sm_switch_to(sm, NCI_RFST_DISCOVERY);
+            return TRUE;
+        case NCI_RF_TIMEOUT_ERROR:
+            GDEBUG("CORE_INTERFACE_ERROR_NTF (Timeout)");
+            nci_sm_switch_to(sm, NCI_RFST_DISCOVERY);
+            return TRUE;
+        }
+    }
+    /* Unrecognized notification */
+    return FALSE;
+}
+
+static
+void
+nci_state_listen_active_rf_deactivate_ntf(
+    NciState* self,
+    const GUtilData* payload)
+{
+    NciSm* sm = nci_state_sm(self);
+
+    /*
+     * Table 62: Control Messages for RF Interface Deactivation
+     *
+     * RF_DEACTIVATE_NTF
+     *
+     * +=========================================================+
+     * | Offset | Size | Description                             |
+     * +=========================================================+
+     * | 0      | 1    | Deactivation Type                       |
+     * | 1      | 1    | Deactivation Reason                     |
+     * +=========================================================+
+     */
+    if (payload->size >= 2) {
+        switch ((NCI_DEACTIVATION_TYPE)payload->bytes[0]) {
+        case NCI_DEACTIVATE_TYPE_SLEEP:
+            GDEBUG("RF_DEACTIVATE_NTF Sleep (%u)", payload->bytes[1]);
+            nci_sm_enter_state(sm, NCI_RFST_LISTEN_SLEEP, NULL);
+            return;
+        case NCI_DEACTIVATE_TYPE_SLEEP_AF:
+            GDEBUG("RF_DEACTIVATE_NTF Sleep_AF (%u)", payload->bytes[1]);
+            nci_sm_enter_state(sm, NCI_RFST_LISTEN_SLEEP, NULL);
+            return;
+        case NCI_DEACTIVATE_TYPE_IDLE:
+        case NCI_DEACTIVATE_TYPE_DISCOVERY:
+            break;
+        }
+    }
+    /* Default handling (transition to IDLE or DISCOVERY) */
+    nci_sm_handle_rf_deactivate_ntf(sm, payload);
+}
+
+/*==========================================================================*
+ * Interface
+ *==========================================================================*/
+
+NciState*
+nci_state_listen_active_new(
+    NciSm* sm)
+{
+    NciState* self = g_object_new(THIS_TYPE, NULL);
+
+    nci_state_init_base(self, sm, NCI_RFST_LISTEN_ACTIVE, "RFST_LISTEN_ACTIVE");
+    return self;
+}
+
+/*==========================================================================*
+ * Methods
+ *==========================================================================*/
+
+static
+void
+nci_state_listen_active_handle_ntf(
+    NciState* self,
+    guint8 gid,
+    guint8 oid,
+    const GUtilData* payload)
+{
+    switch (gid) {
+    case NCI_GID_CORE:
+        switch (oid) {
+        case NCI_OID_CORE_INTERFACE_ERROR:
+            if (nci_state_listen_active_interface_error_ntf(self, payload)) {
+                return;
+            }
+            break;
+        }
+        break;
+    case NCI_GID_RF:
+        switch (oid) {
+        case NCI_OID_RF_DEACTIVATE:
+            nci_state_listen_active_rf_deactivate_ntf(self, payload);
+            return;
+        }
+        break;
+    }
+    NCI_STATE_CLASS(PARENT_CLASS)->handle_ntf(self, gid, oid, payload);
+}
+
+/*==========================================================================*
+ * Internals
+ *==========================================================================*/
+
+static
+void
+nci_state_listen_active_init(
+    NciStateListenActive* self)
+{
+}
+
+static
+void
+nci_state_listen_active_class_init(
+    NciStateListenActiveClass* klass)
+{
+    NCI_STATE_CLASS(klass)->handle_ntf = nci_state_listen_active_handle_ntf;
+}
+
+/*
+ * Local Variables:
+ * mode: C
+ * c-basic-offset: 4
+ * indent-tabs-mode: nil
+ * End:
+ */

--- a/src/nci_state_listen_sleep.c
+++ b/src/nci_state_listen_sleep.c
@@ -1,0 +1,200 @@
+/*
+ * Copyright (C) 2020 Jolla Ltd.
+ * Copyright (C) 2020 Slava Monich <slava.monich@jolla.com>
+ *
+ * You may use this file under the terms of BSD license as follows:
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *   1. Redistributions of source code must retain the above copyright
+ *      notice, this list of conditions and the following disclaimer.
+ *   2. Redistributions in binary form must reproduce the above copyright
+ *      notice, this list of conditions and the following disclaimer in the
+ *      documentation and/or other materials provided with the distribution.
+ *   3. Neither the names of the copyright holders nor the names of its
+ *      contributors may be used to endorse or promote products derived
+ *      from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "nci_sm.h"
+#include "nci_state_impl.h"
+#include "nci_util.h"
+#include "nci_log.h"
+
+typedef NciState NciStateListenSleep;
+typedef NciStateClass NciStateListenSleepClass;
+
+GType nci_state_listen_sleep_get_type(void) NCI_INTERNAL;
+#define THIS_TYPE (nci_state_listen_sleep_get_type())
+#define PARENT_CLASS (nci_state_listen_sleep_parent_class)
+
+G_DEFINE_TYPE(NciStateListenSleep, nci_state_listen_sleep, NCI_TYPE_STATE)
+
+/*==========================================================================*
+ * Implementation
+ *==========================================================================*/
+
+static
+void
+nci_state_listen_sleep_intf_activated_ntf(
+    NciState* self,
+    const GUtilData* payload)
+{
+    NciIntfActivationNtf ntf;
+    NciModeParam mode_param;
+    NciActivationParam activation_param;
+    NciSm* sm = nci_state_sm(self);
+
+    /*
+     * 5.2.7 State RFST_LISTEN_SLEEP
+     *
+     * ...
+     * If the NFCC receives a valid RF wake up command(s) followed
+     * by successful activation procedure, the NFCC SHALL send
+     * RF_INTF_ACTIVATED_NTF (Listen mode) to the DH. At that point,
+     * the state is changed back to RFST_LISTEN_ACTIVE.
+     */
+    if (nci_parse_intf_activated_ntf(&ntf, &mode_param, &activation_param,
+        payload->bytes, payload->size)) {
+        nci_sm_intf_activated(sm, &ntf);
+        if (nci_listen_mode(ntf.mode)) {
+            nci_sm_enter_state(sm, NCI_RFST_LISTEN_ACTIVE, NULL);
+            return;
+        } else {
+            GDEBUG("Unexpected activation mode 0x%02x", ntf.mode);
+        }
+    }
+    /* Oops */
+    nci_sm_stall(sm, NCI_STALL_ERROR);
+}
+
+static
+void
+nci_state_listen_sleep_rf_deactivate_ntf(
+    NciState* self,
+    const GUtilData* payload)
+{
+    NciSm* sm = nci_state_sm(self);
+
+    /*
+     * Table 62: Control Messages for RF Interface Deactivation
+     *
+     * RF_DEACTIVATE_NTF
+     *
+     * +=========================================================+
+     * | Offset | Size | Description                             |
+     * +=========================================================+
+     * | 0      | 1    | Deactivation Type                       |
+     * | 1      | 1    | Deactivation Reason                     |
+     * +=========================================================+
+     */
+    if (payload->size >= 2) {
+        const NCI_DEACTIVATION_TYPE type = payload->bytes[0];
+
+        switch (type) {
+        case NCI_DEACTIVATE_TYPE_DISCOVERY:
+            /*
+             * 5.2.7 State RFST_LISTEN_SLEEP
+             *
+             * ...
+             * On detection of remote RF field off, the NFCC SHALL send
+             * RF_DEACTIVATE_NTF (Discovery, RF Link Loss) to the DH. The
+             * RF Communication state will then change to RFST_DISCOVERY.
+             */
+            GDEBUG("RF_DEACTIVATE_NTF Discovery (%d)", payload->bytes[1]);
+            nci_sm_enter_state(sm, NCI_RFST_DISCOVERY, NULL);
+            return;
+        case NCI_DEACTIVATE_TYPE_SLEEP_AF:
+        case NCI_DEACTIVATE_TYPE_SLEEP:
+        case NCI_DEACTIVATE_TYPE_IDLE:
+            break;
+        }
+        GDEBUG("Unexpected RF_DEACTIVATE_NTF %d (%u)", type, payload->bytes[1]);
+    } else {
+        GWARN("Failed to parse RF_DEACTIVATE_NTF");
+    }
+    /* Oops */
+    nci_sm_stall(sm, NCI_STALL_ERROR);
+}
+
+/*==========================================================================*
+ * Interface
+ *==========================================================================*/
+
+NciState*
+nci_state_listen_sleep_new(
+    NciSm* sm)
+{
+    NciState* self = g_object_new(THIS_TYPE, NULL);
+
+    nci_state_init_base(self, sm, NCI_RFST_LISTEN_SLEEP, "RFST_LISTEN_SLEEP");
+    return self;
+}
+
+/*==========================================================================*
+ * Methods
+ *==========================================================================*/
+
+static
+void
+nci_state_listen_sleep_handle_ntf(
+    NciState* self,
+    guint8 gid,
+    guint8 oid,
+    const GUtilData* payload)
+{
+    switch (gid) {
+    case NCI_GID_RF:
+        switch (oid) {
+        case NCI_OID_RF_INTF_ACTIVATED:
+            nci_state_listen_sleep_intf_activated_ntf(self, payload);
+            return;
+        case NCI_OID_RF_DEACTIVATE:
+            nci_state_listen_sleep_rf_deactivate_ntf(self, payload);
+            return;
+        }
+        break;
+    }
+    NCI_STATE_CLASS(PARENT_CLASS)->handle_ntf(self, gid, oid, payload);
+}
+
+/*==========================================================================*
+ * Internals
+ *==========================================================================*/
+
+static
+void
+nci_state_listen_sleep_init(
+    NciStateListenSleep* self)
+{
+}
+
+static
+void
+nci_state_listen_sleep_class_init(
+    NciStateListenSleepClass* klass)
+{
+    NCI_STATE_CLASS(klass)->handle_ntf = nci_state_listen_sleep_handle_ntf;
+}
+
+/*
+ * Local Variables:
+ * mode: C
+ * c-basic-offset: 4
+ * indent-tabs-mode: nil
+ * End:
+ */

--- a/src/nci_transition.h
+++ b/src/nci_transition.h
@@ -88,27 +88,27 @@ nci_transition_handle_ntf(
 
 /* Specific transitions */
 
-NciTransition* 
+NciTransition*
 nci_transition_reset_new(
     NciSm* sm)
     NCI_INTERNAL;
 
-NciTransition* 
+NciTransition*
 nci_transition_idle_to_discovery_new(
     NciSm* sm)
     NCI_INTERNAL;
 
-NciTransition* 
+NciTransition*
+nci_transition_deactivate_to_discovery_new(
+    NciSm* sm)
+    NCI_INTERNAL;
+
+NciTransition*
 nci_transition_deactivate_to_idle_new(
     NciSm* sm)
     NCI_INTERNAL;
 
-NciTransition* 
-nci_transition_poll_active_to_discovery_new(
-    NciSm* sm)
-    NCI_INTERNAL;
-
-NciTransition* 
+NciTransition*
 nci_transition_poll_active_to_idle_new(
     NciSm* sm)
     NCI_INTERNAL;

--- a/src/nci_transition_deactivate_to_discovery.c
+++ b/src/nci_transition_deactivate_to_discovery.c
@@ -1,6 +1,6 @@
 /*
- * Copyright (C) 2019 Jolla Ltd.
- * Copyright (C) 2019 Slava Monich <slava.monich@jolla.com>
+ * Copyright (C) 2019-2020 Jolla Ltd.
+ * Copyright (C) 2019-2020 Slava Monich <slava.monich@jolla.com>
  *
  * You may use this file under the terms of BSD license as follows:
  *
@@ -46,15 +46,23 @@
  * where the NFCC SHALL either restart or continue the Polling discovery
  * activity.
  *
+ * 5.2.6 State RFST_LISTEN_ACTIVE
+ *
+ * ...
+ * DH SHALL send RF_DEACTIVATE_CMD (Discovery) to the NFCC, which SHALL
+ * answer RF_DEACTIVATE_RSP followed by RF_DEACTIVATE_NTF (Discovery,
+ * DH Request). The state will then change to RFST_DISCOVERY.
  *==========================================================================*/
 
-typedef NciTransition NciTransitionPollActiveToDiscovery;
-typedef NciTransitionClass NciTransitionPollActiveToDiscoveryClass;
+typedef NciTransition NciTransitionDeactivateToDiscovery;
+typedef NciTransitionClass NciTransitionDeactivateToDiscoveryClass;
 
-G_DEFINE_TYPE(NciTransitionPollActiveToDiscovery,
-    nci_transition_poll_active_to_discovery, NCI_TYPE_TRANSITION)
-#define THIS_TYPE (nci_transition_poll_active_to_discovery_get_type())
-#define PARENT_CLASS (nci_transition_poll_active_to_discovery_parent_class)
+GType nci_transition_deactivate_to_discovery_get_type(void) NCI_INTERNAL;
+#define THIS_TYPE (nci_transition_deactivate_to_discovery_get_type())
+#define PARENT_CLASS (nci_transition_deactivate_to_discovery_parent_class)
+
+G_DEFINE_TYPE(NciTransitionDeactivateToDiscovery,
+    nci_transition_deactivate_to_discovery, NCI_TYPE_TRANSITION)
 
 /*==========================================================================*
  * Implementation
@@ -62,7 +70,7 @@ G_DEFINE_TYPE(NciTransitionPollActiveToDiscovery,
 
 static
 void
-nci_transition_poll_active_to_discovery_idle_rsp(
+nci_transition_deactivate_to_discovery_idle_rsp(
     NCI_REQUEST_STATUS status,
     const GUtilData* payload,
     NciTransition* self)
@@ -91,7 +99,7 @@ nci_transition_poll_active_to_discovery_idle_rsp(
 
 static
 void
-nci_transition_poll_active_to_discovery_rsp(
+nci_transition_deactivate_to_discovery_rsp(
     NCI_REQUEST_STATUS status,
     const GUtilData* payload,
     NciTransition* self)
@@ -112,7 +120,7 @@ nci_transition_poll_active_to_discovery_rsp(
             /* Try to deactivate to IDLE */
             GWARN("RF_DEACTIVATE_CMD (Discovery) failed");
             nci_transition_deactivate_to_idle(self,
-                nci_transition_poll_active_to_discovery_idle_rsp);
+                nci_transition_deactivate_to_discovery_idle_rsp);
         }
     } else {
         nci_transition_stall(self, NCI_STALL_ERROR);
@@ -123,8 +131,8 @@ nci_transition_poll_active_to_discovery_rsp(
  * Interface
  *==========================================================================*/
 
-NciTransition* 
-nci_transition_poll_active_to_discovery_new(
+NciTransition*
+nci_transition_deactivate_to_discovery_new(
     NciSm* sm)
 {
     NciState* dest = nci_sm_get_state(sm, NCI_RFST_DISCOVERY);
@@ -144,16 +152,16 @@ nci_transition_poll_active_to_discovery_new(
 
 static
 gboolean
-nci_transition_poll_active_to_discovery_start(
+nci_transition_deactivate_to_discovery_start(
     NciTransition* self)
 {
     return nci_transition_deactivate_to_discovery(self,
-        nci_transition_poll_active_to_discovery_rsp);
+        nci_transition_deactivate_to_discovery_rsp);
 }
 
 static
 void
-nci_transition_poll_active_to_discovery_handle_ntf(
+nci_transition_deactivate_to_discovery_handle_ntf(
     NciTransition* self,
     guint8 gid,
     guint8 oid,
@@ -177,18 +185,18 @@ nci_transition_poll_active_to_discovery_handle_ntf(
 
 static
 void
-nci_transition_poll_active_to_discovery_init(
-    NciTransitionPollActiveToDiscovery* self)
+nci_transition_deactivate_to_discovery_init(
+    NciTransitionDeactivateToDiscovery* self)
 {
 }
 
 static
 void
-nci_transition_poll_active_to_discovery_class_init(
-    NciTransitionPollActiveToDiscoveryClass* klass)
+nci_transition_deactivate_to_discovery_class_init(
+    NciTransitionDeactivateToDiscoveryClass* klass)
 {
-    klass->start = nci_transition_poll_active_to_discovery_start;
-    klass->handle_ntf = nci_transition_poll_active_to_discovery_handle_ntf;
+    klass->start = nci_transition_deactivate_to_discovery_start;
+    klass->handle_ntf = nci_transition_deactivate_to_discovery_handle_ntf;
 }
 
 /*

--- a/src/nci_util.h
+++ b/src/nci_util.h
@@ -35,6 +35,11 @@
 
 #include "nci_types_p.h"
 
+gboolean
+nci_listen_mode(
+    NCI_MODE mode)
+    NCI_INTERNAL;
+
 const NciModeParam*
 nci_parse_mode_param(
     NciModeParam* param,


### PR DESCRIPTION
This adds support for the remaining two states, `RFST_LISTEN_SLEEP` and `RFST_LISTEN_ACTIVE`. Now the state machine is complete, at least according to NCI 1.0 spec.