### PR TITLE
[ncicore] Add support for technology specific parameters. JB#50041.

### DIFF
--- a/include/nci_types.h
+++ b/include/nci_types.h
@@ -130,6 +130,9 @@ typedef struct nci_mode_param_poll_a {
 typedef struct nci_mode_param_poll_b {
     guint8 nfcid0[4];
     guint fsc;  /* FSCI converted to bytes */
+    /* Since 1.1.5 */
+    guint8 app_data[4];
+    GUtilData prot_info;
 } NciModeParamPollB;
 
 /* Table 58: Specific Parameters for NFC-F Poll Mode */

--- a/include/nci_types.h
+++ b/include/nci_types.h
@@ -159,6 +159,13 @@ typedef struct nci_activation_param_iso_dep_poll_a {
     GUtilData t1;  /* T1 to Tk (otherwise called historical bytes) */
 } NciActivationParamIsoDepPollA;
 
+/* Table 75: Activation Parameters for NFC-B/ISO-DEP Poll Mode */
+typedef struct nci_activation_param_iso_dep_poll_b {
+    guint mbli;     /* Maximum buffer length index */
+    guint did;      /* Device ID */
+    GUtilData hilr; /* Higher Layer Response */
+} NciActivationParamIsoDepPollB;
+
 /* Table 82: Activation Parameters for NFC-DEP Poll Mode */
 typedef struct nci_activation_param_nfc_dep_poll {
     /* ATR_RES starting from and including Byte 3 */
@@ -184,6 +191,7 @@ typedef struct nci_activation_param_nfc_dep_listen {
 
 typedef union nci_activation_param {
     NciActivationParamIsoDepPollA iso_dep_poll_a;
+    NciActivationParamIsoDepPollB iso_dep_poll_b;  /* Since 1.1.5 */
     NciActivationParamNfcDepPoll nfc_dep_poll;     /* Since 1.0.8 */
     NciActivationParamNfcDepListen nfc_dep_listen; /* Since 1.0.8 */
 } NciActivationParam;

--- a/src/nci_util.c
+++ b/src/nci_util.c
@@ -178,11 +178,30 @@ nci_parse_mode_param(
             ppb->fsc = (fsci < G_N_ELEMENTS(fsc_table)) ?
                 fsc_table[fsci] :
                 fsc_table[G_N_ELEMENTS(fsc_table) - 1];
+            memcpy(ppb->app_data, bytes + 5, 4);
+            ppb->prot_info.size = bytes[0] - 8;
+            ppb->prot_info.bytes = bytes + 9;
 
-            GDEBUG("NFC-B");
-            GDEBUG("  PollB.fsc = %u", ppb->fsc);
-            GDEBUG("  PollB.nfcid0 = %02x %02x %02x %02x", ppb->nfcid0[0],
-                ppb->nfcid0[1], ppb->nfcid0[2], ppb->nfcid0[3]);
+#if GUTIL_LOG_DEBUG
+            if (GLOG_ENABLED(GLOG_LEVEL_DEBUG)) {
+                GString *buf = g_string_new(NULL);
+                guint i;
+
+                for (i = 0; i < ppb->prot_info.size; i++) {
+                    g_string_append_printf(buf, " %02x",
+                        ppb->prot_info.bytes[i]);
+                }
+                GDEBUG("NFC-B");
+                GDEBUG("  PollB.fsc = %u", ppb->fsc);
+                GDEBUG("  PollB.nfcid0 = %02x %02x %02x %02x", ppb->nfcid0[0],
+                    ppb->nfcid0[1], ppb->nfcid0[2], ppb->nfcid0[3]);
+                GDEBUG("  PollB.AppData = %02x %02x %02x %02x",
+                    ppb->app_data[0], ppb->app_data[1], ppb->app_data[2],
+                    ppb->app_data[3]);
+                GDEBUG("  PollB.ProtInfo =%s", buf->str);
+                g_string_free(buf, TRUE);
+            }
+#endif
             return param;
         }
         GDEBUG("Failed to parse parameters for NFC-B poll mode");

--- a/src/nci_util.c
+++ b/src/nci_util.c
@@ -423,6 +423,66 @@ nci_parse_iso_dep_poll_a_param(
 
 static
 gboolean
+nci_parse_iso_dep_poll_b_param(
+    NciActivationParamIsoDepPollB* param,
+    const guint8* bytes,
+    guint len)
+{
+    /* NFCFrum-TS-NCI-1.0
+     * Table 75: Activation parameters for NFC-B/ISO-DEP Poll Mode
+     *
+     * +============================================================+
+     * | Offset | Size | Description                                |
+     * +============================================================+
+     * | 0      | 1    | Length of ATTRIB Response Parameter (n)    |
+     * | 1      | n    | ATTRIB Response                            |
+     * +============================================================+
+     */
+
+    /* ATTRIB Response */
+    const guint attrib_length = bytes[0];
+
+    if (attrib_length >= 1) {
+        /* NFCForum-TS-DigitalProtocol-1.01
+         * Table 79: ATTRIB Response Format */
+
+#define NFC_T4B_MBLI_MASK (0xF0) /* MBLI Mask */
+#define NFC_T4B_DID_MASK  (0x0F) /* DID Mask */
+
+        /* First two octets of the first byte of ATTRIB Response */
+        param->mbli = (bytes[1] & NFC_T4B_MBLI_MASK) >> 4;
+        param->did  = (bytes[1] & NFC_T4B_DID_MASK);
+
+        /* Higher Layer Response */
+        if (attrib_length >= 2) {
+            param->hilr.bytes = bytes + 2;
+            param->hilr.size = attrib_length - 1;
+        }
+
+#if GUTIL_LOG_DEBUG
+        if (GLOG_ENABLED(GLOG_LEVEL_DEBUG)) {
+            GDEBUG("ISO-DEP");
+            GDEBUG("  MBLI = %u", param->mbli);
+            GDEBUG("  DID = %u", param->did);
+            if (param->hilr.size > 0) {
+                GString *buf = g_string_new(NULL);
+                guint i;
+
+                for (i = 0; i < param->hilr.size; i++) {
+                    g_string_append_printf(buf, " %02x", bytes[i]);
+                }
+                GDEBUG("  HigherLayer Response =%s", buf->str);
+                g_string_free(buf, TRUE);
+            }
+        }
+#endif
+        return TRUE;
+    }
+    return FALSE;
+}
+
+static
+gboolean
 nci_parse_nfc_dep_poll_param(
     NciActivationParamNfcDepPoll* param,
     const guint8* bytes,
@@ -576,6 +636,12 @@ nci_parse_activation_param(
             GDEBUG("Failed to parse parameters for NFC-A/ISO-DEP poll mode");
             break;
         case NCI_MODE_PASSIVE_POLL_B:
+            if (nci_parse_iso_dep_poll_b_param(&param->iso_dep_poll_b,
+                bytes, len)) {
+                return param;
+            }
+            GDEBUG("Failed to parse parameters for NFC-B/ISO-DEP poll mode");
+            break;
         case NCI_MODE_PASSIVE_POLL_F:
         case NCI_MODE_ACTIVE_POLL_F:
         case NCI_MODE_PASSIVE_POLL_15693:

--- a/unit/nci_util/test_nci_util.c
+++ b/unit/nci_util/test_nci_util.c
@@ -151,12 +151,16 @@ static const TestModeParamSuccessData mode_param_success_tests[] = {
         .name = "poll_b",
         .mode = NCI_MODE_PASSIVE_POLL_B,
         .data = { TEST_ARRAY_AND_SIZE(mode_param_success_data_poll_b) },
-        .expected = { .poll_b = { {0x65, 0xe6, 0x70, 0x15}, 256 } }
+        .expected = { .poll_b = { {0x65, 0xe6, 0x70, 0x15}, 256,
+                                  {0xe1, 0xf3, 0x5e, 0x11},
+                                  {mode_param_success_data_poll_b + 9, 3}}}
     },{
         .name = "poll_b_rfu", /* RFU part of FSCI to FSC conversion table */
         .mode = NCI_MODE_PASSIVE_POLL_B,
         .data = { TEST_ARRAY_AND_SIZE(mode_param_success_data_poll_b_rfu) },
-        .expected = { .poll_b = { {0x65, 0xe6, 0x70, 0x15}, 256 } }
+        .expected = { .poll_b = { {0x65, 0xe6, 0x70, 0x15}, 256,
+                                  {0xe1, 0xf3, 0x5e, 0x11},
+                                  {mode_param_success_data_poll_b_rfu + 9, 3}}}
     },{
         .name = "active_poll_f",
         .mode = NCI_MODE_ACTIVE_POLL_F,

--- a/unit/nci_util/test_nci_util.c
+++ b/unit/nci_util/test_nci_util.c
@@ -391,6 +391,20 @@ static const guint8 test_intf_activated_ntf_nfc_dep_listen_2[] = {
     0x00, 0x32
 };
 
+static const guint8 test_intf_activated_ntf_iso_dep_poll_1[] = {
+    0x01, 0x02, 0x04, 0x01, 0xff, 0x01, 0x0c, 0x0b,
+    0xdb, 0xa2, 0xa2, 0x2b, 0x52, 0x74, 0x4d, 0x43,
+    0x00, 0x81, 0xc1, 0x01, 0x00, 0x00, 0x02, 0x01,
+    0x00
+};
+
+static const guint8 test_intf_activated_ntf_iso_dep_poll_2[] = {
+    0x01, 0x02, 0x04, 0x01, 0xff, 0x01, 0x0c, 0x0b,
+    0xdb, 0xa2, 0xa2, 0x2b, 0x52, 0x74, 0x4d, 0x43,
+    0x00, 0x81, 0xc1, 0x01, 0x00, 0x00, 0x05, 0x04,
+    0x00, 0x01, 0x02, 0x03
+};
+
 static const NciModeParam test_intf_activated_ntf_mifare_mp = {
     .poll_a = {
         .sens_res = { 0x44, 0x00 },
@@ -407,6 +421,22 @@ static const NciModeParam test_intf_activated_ntf_poll_a_mp = {
         .nfcid1 = { 0x08, 0x50, 0xad, 0x0e },
         .sel_res_len = 1,
         .sel_res = 0x40
+    }
+};
+static const NciModeParam test_intf_activated_ntf_poll_b_mp_1 = {
+    .poll_b = {
+        .nfcid0 = {0xdb, 0xa2, 0xa2, 0x2b},
+        .fsc = 256,
+        .app_data = {0x52, 0x74, 0x4d, 0x43},
+        .prot_info = { test_intf_activated_ntf_iso_dep_poll_1 + 0x10, 3 }
+    }
+};
+static const NciModeParam test_intf_activated_ntf_poll_b_mp_2 = {
+    .poll_b = {
+        .nfcid0 = {0xdb, 0xa2, 0xa2, 0x2b},
+        .fsc = 256,
+        .app_data = {0x52, 0x74, 0x4d, 0x43},
+        .prot_info = { test_intf_activated_ntf_iso_dep_poll_2 + 0x10, 3 }
     }
 };
 static const NciActivationParam test_intf_activated_ntf_nfc_dep_poll_ap_1 = {
@@ -465,6 +495,21 @@ static const NciActivationParam test_intf_activated_ntf_nfc_dep_listen_ap_2 = {
         .pp = 0x32
     }
 };
+static const NciActivationParam test_intf_activated_ntf_iso_dep_poll_ap_1 = {
+    .iso_dep_poll_b = {
+        .mbli = 0x00,
+        .did = 0x00,
+        .hilr = { NULL, 0 },
+    }
+};
+
+static const NciActivationParam test_intf_activated_ntf_iso_dep_poll_ap_2 = {
+    .iso_dep_poll_b = {
+        .mbli = 0x00,
+        .did = 0x00,
+        .hilr = { test_intf_activated_ntf_iso_dep_poll_2 + 0x19, 3 },
+    }
+};
 
 static const TestIntfActivatedSuccessData intf_activated_success_tests[] = {
     {
@@ -494,6 +539,16 @@ static const TestIntfActivatedSuccessData intf_activated_success_tests[] = {
         .name = "nfc_dep_listen/ok/2",
         .data = {TEST_ARRAY_AND_SIZE(test_intf_activated_ntf_nfc_dep_listen_2)},
         .activation_param = &test_intf_activated_ntf_nfc_dep_listen_ap_2
+    },{
+        .name = "iso_dep_poll/ok/1",
+        .data = {TEST_ARRAY_AND_SIZE(test_intf_activated_ntf_iso_dep_poll_1)},
+        .mode_param = &test_intf_activated_ntf_poll_b_mp_1,
+        .activation_param = &test_intf_activated_ntf_iso_dep_poll_ap_1
+    },{
+        .name = "iso_dep_poll/ok/2",
+        .data = {TEST_ARRAY_AND_SIZE(test_intf_activated_ntf_iso_dep_poll_2)},
+        .mode_param = &test_intf_activated_ntf_poll_b_mp_2,
+        .activation_param = &test_intf_activated_ntf_iso_dep_poll_ap_2
     }
 };
 
@@ -558,6 +613,13 @@ static const guint8 test_intf_activated_ntf_nfc_dep_fail_4[] = {
                /* ^^    ^^ ATR_REQ too short */
 };
 
+static const guint8 test_intf_activated_ntf_iso_dep_fail_1[] = {
+    0x01, 0x02, 0x04, 0x01, 0xff, 0x01, 0x0c, 0x0b,
+    0xdb, 0xa2, 0xa2, 0x2b, 0x52, 0x74, 0x4d, 0x43,
+    0x00, 0x81, 0xc1, 0x01, 0x00, 0x00, 0x01, 0x00,
+          /* ATTRIB Response is too short ^^    ^^ */
+};
+
 static const TestIntfActivatedFailData intf_activated_fail_tests[] = {
     {
         .name = "nfc_dep_1",
@@ -575,6 +637,10 @@ static const TestIntfActivatedFailData intf_activated_fail_tests[] = {
         .name = "nfc_dep_4",
         .data = {TEST_ARRAY_AND_SIZE(test_intf_activated_ntf_nfc_dep_fail_4)},
         .parse_ok = TRUE, .mode_param_ok = FALSE, .activation_param_ok = FALSE
+    },{
+        .name = "iso_dep_1",
+        .data = {TEST_ARRAY_AND_SIZE(test_intf_activated_ntf_iso_dep_fail_1)},
+        .parse_ok = TRUE, .mode_param_ok = TRUE, .activation_param_ok = FALSE
     }
 };
 


### PR DESCRIPTION
Added support for NFC-B Poll Mode parameters and NFC-B ISO-DEP Activation parameters according to NFCForum-TS-NCI-1.0 and NFCForum-TS-DigitalProtocol-1.0 specifications. 