### PR TITLE
Fixed offsets of middle chunks in segmented packets

### DIFF
--- a/src/nci_sar.c
+++ b/src/nci_sar.c
@@ -255,7 +255,7 @@ nci_sar_attempt_write(
                 /* Send a fragment */
                 out->hdr[0] |= NCI_PBF;
                 out->hdr[2] = max_payload_size;
-                chunks[nchunks].bytes = payload;
+                chunks[nchunks].bytes = payload + out->payload_pos;
                 chunks[nchunks].size = max_payload_size;
                 out->payload_pos += chunks[nchunks].size;
                 nchunks++;

--- a/unit/nci_sar/test_nci_sar.c
+++ b/unit/nci_sar/test_nci_sar.c
@@ -688,7 +688,7 @@ test_send_data_seg(
     void)
 {
     /* Set MTU to minimum and send one byte of payload per data packet */
-    static const guint8 payload[] = { 0x01, 0x02 };
+    static const guint8 payload[] = { 0x01, 0x02, 0x03 };
     GBytes* payload_bytes = g_bytes_new_static(payload, sizeof(payload));
     NciSarClient client;
     TestHalIo* test_io = test_hal_io_new();


### PR DESCRIPTION
Curiously, unit test didn't catch it because the first and the last chunks were sent correctly, and unit test had only two chunks. At least three chunks were necessary to catch this bug.