### PR TITLE
Issue INTF_ACTIVATED signal after state change

### DIFF
--- a/src/nci_state_discovery.c
+++ b/src/nci_state_discovery.c
@@ -75,12 +75,17 @@ nci_state_discovery_intf_activated_ntf(
      */
     if (nci_parse_intf_activated_ntf(&ntf, &mode_param, &activation_param,
         payload->bytes, payload->size)) {
-        nci_sm_intf_activated(sm, &ntf);
+        /*
+         * Switch the state first because RF_INTF_ACTIVATED_NTF handler
+         * may want to change the state again (e.g. if configuration is
+         * unsupported).
+         */
         if (nci_listen_mode(ntf.mode)) {
             nci_sm_enter_state(sm, NCI_RFST_LISTEN_ACTIVE, NULL);
         } else {
             nci_sm_enter_state(sm, NCI_RFST_POLL_ACTIVE, NULL);
         }
+        nci_sm_intf_activated(sm, &ntf);
     } else {
         /* Deactivate this target */
         nci_sm_enter_state(sm, NCI_RFST_POLL_ACTIVE, NULL);

--- a/src/nci_state_listen_sleep.c
+++ b/src/nci_state_listen_sleep.c
@@ -70,9 +70,14 @@ nci_state_listen_sleep_intf_activated_ntf(
      */
     if (nci_parse_intf_activated_ntf(&ntf, &mode_param, &activation_param,
         payload->bytes, payload->size)) {
-        nci_sm_intf_activated(sm, &ntf);
         if (nci_listen_mode(ntf.mode)) {
+            /*
+             * Switch the state first because RF_INTF_ACTIVATED_NTF handler
+             * may want to change the state again (e.g. if configuration is
+             * unsupported).
+             */
             nci_sm_enter_state(sm, NCI_RFST_LISTEN_ACTIVE, NULL);
+            nci_sm_intf_activated(sm, &ntf);
             return;
         } else {
             GDEBUG("Unexpected activation mode 0x%02x", ntf.mode);

--- a/src/nci_state_w4_host_select.c
+++ b/src/nci_state_w4_host_select.c
@@ -227,24 +227,13 @@ nci_state_w4_host_select_handle_intf_activated_ntf(
      */
     if (nci_parse_intf_activated_ntf(&ntf, &mode_param, &activation_param,
         payload->bytes, payload->size)) {
-
-        /* Notify the handler(s) */
-        nci_sm_intf_activated(sm, &ntf);
-
         /*
-         * If RF_INTF_ACTIVATED_NTF handler is unhappy with the selected
-         * configuration, it may decide to deactivate RF interface by
-         * initiating a transition to NCI_RFST_IDLE or NCI_RFST_DISCOVERY
-         * state. That switches the next state to NCI_RFST_IDLE. In this
-         * case we just let that transition to happily run to the end.
-         *
-         * If handler is happy (or there's no handler) the state remains
-         * RFST_W4_HOST_SELECT and we can switch the state machine to
-         * NCI_RFST_POLL_ACTIVE.
+         * Switch the state first because RF_INTF_ACTIVATED_NTF handler
+         * may want to change the state again (e.g. if configuration is
+         * unsupported).
          */
-        if (sm->next_state == self) {
-            nci_sm_enter_state(sm, NCI_RFST_POLL_ACTIVE, NULL);
-        }
+        nci_sm_enter_state(sm, NCI_RFST_POLL_ACTIVE, NULL);
+        nci_sm_intf_activated(sm, &ntf);
     } else {
         /* Deactivate this target */
         nci_sm_enter_state(sm, NCI_RFST_POLL_ACTIVE, NULL);


### PR DESCRIPTION
When we receive RF_INTF_ACTIVATED_NTF, the current state needs to be changed no matter what. Then INTF_ACTIVATED handler can do whatever, e.g. request transition to another state if it's unhappy with the currently selected configuration.