### PR TITLE
[Makefile] Update libncicore.pc when version header changes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -240,7 +240,7 @@ $(RELEASE_BUILD_DIR)/$(LIB_SYMLINK2): $(RELEASE_LIB)
 LIBDIR ?= usr/lib
 ABS_LIBDIR := $(shell echo /$(LIBDIR) | sed -r 's|/+|/|g')
 
-$(PKGCONFIG): $(LIB_NAME).pc.in Makefile
+$(PKGCONFIG): $(LIB_NAME).pc.in $(VERSION_FILE)
 	sed -e 's|@version@|$(PCVERSION)|g' -e 's|@libdir@|$(ABS_LIBDIR)|g' $< > $@
 
 debian/%.install: debian/%.install.in


### PR DESCRIPTION
Because the pkgconfig version is extracted from a header, updating the repo can lead to an old version of the libnciconfig.pc being bundled with the package. This patch puts a hint in the Makefile to watch the version header for changes.