### PR TITLE
[libncicore] Add functions to deep copy mode- and activation- params. JB#51201

### DIFF
--- a/include/nci_util.h
+++ b/include/nci_util.h
@@ -1,6 +1,7 @@
 /*
- * Copyright (C) 2019 Jolla Ltd.
- * Copyright (C) 2019 Slava Monich <slava.monich@jolla.com>
+ * Copyright (C) 2019-2020 Jolla Ltd.
+ * Copyright (C) 2019-2020 Slava Monich <slava.monich@jolla.com>
+ * Copyright (C) 2020 Open Mobile Platform LLC.
  *
  * You may use this file under the terms of BSD license as follows:
  *
@@ -30,59 +31,29 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include "nci_param_w4_host_select.h"
-#include "nci_param_impl.h"
-#include "nci_util_p.h"
+#ifndef NCI_UTIL_H
+#define NCI_UTIL_H
 
-typedef NciParamClass NciParamW4HostSelectClass;
-G_DEFINE_TYPE(NciParamW4HostSelect, nci_param_w4_host_select, NCI_TYPE_PARAM)
+#include <nci_types.h>
 
-/*==========================================================================*
- * Interface
- *==========================================================================*/
+G_BEGIN_DECLS
 
-NciParamW4HostSelect*
-nci_param_w4_host_select_new(
-    const NciDiscoveryNtf* const* ntf,
-    guint count)
-{
-    NciParamW4HostSelect* self =
-        g_object_new(NCI_TYPE_PARAM_W4_HOST_SELECT, NULL);
+/* Free the result with g_free() */
+NciModeParam*
+nci_util_copy_mode_param(
+    const NciModeParam* param,
+    NCI_MODE mode); /* Since 1.1.13 */
 
-    self->ntf = nci_discovery_ntf_copy_array(ntf, count);
-    self->count = count;
-    return self;
-}
+/* Free the result with g_free() */
+NciActivationParam*
+nci_util_copy_activation_param(
+    const NciActivationParam* param,
+    NCI_RF_INTERFACE intf,
+    NCI_MODE mode); /* Since 1.1.13 */
 
-/*==========================================================================*
- * Internals
- *==========================================================================*/
+G_END_DECLS
 
-static
-void
-nci_param_w4_host_select_init(
-    NciParamW4HostSelect* self)
-{
-}
-
-static
-void
-nci_param_w4_host_select_finalize(
-    GObject* obj)
-{
-    NciParamW4HostSelect* self = NCI_PARAM_W4_HOST_SELECT(obj);
-
-    g_free(self->ntf);
-    G_OBJECT_CLASS(nci_param_w4_host_select_parent_class)->finalize(obj);
-}
-
-static
-void
-nci_param_w4_host_select_class_init(
-    NciParamClass* klass)
-{
-    G_OBJECT_CLASS(klass)->finalize = nci_param_w4_host_select_finalize;
-}
+#endif /* NCI_UTIL_H */
 
 /*
  * Local Variables:

--- a/libncicore.map
+++ b/libncicore.map
@@ -2,6 +2,7 @@
     global:
         nci_core_*;
         nci_log;
+        nci_util_*;
     local:
         *;
 };

--- a/src/nci_param_w4_all_discoveries.c
+++ b/src/nci_param_w4_all_discoveries.c
@@ -32,7 +32,7 @@
 
 #include "nci_param_w4_all_discoveries.h"
 #include "nci_param_impl.h"
-#include "nci_util.h"
+#include "nci_util_p.h"
 
 typedef NciParamClass NciParamW4AllDiscoveriesClass;
 G_DEFINE_TYPE(NciParamW4AllDiscoveries, nci_param_w4_all_discoveries,

--- a/src/nci_state_discovery.c
+++ b/src/nci_state_discovery.c
@@ -34,7 +34,7 @@
 #include "nci_sar.h"
 #include "nci_state_impl.h"
 #include "nci_param_w4_all_discoveries.h"
-#include "nci_util.h"
+#include "nci_util_p.h"
 #include "nci_log.h"
 
 typedef NciState NciStateDiscovery;

--- a/src/nci_state_listen_sleep.c
+++ b/src/nci_state_listen_sleep.c
@@ -32,7 +32,7 @@
 
 #include "nci_sm.h"
 #include "nci_state_impl.h"
-#include "nci_util.h"
+#include "nci_util_p.h"
 #include "nci_log.h"
 
 typedef NciState NciStateListenSleep;

--- a/src/nci_state_w4_all_discoveries.c
+++ b/src/nci_state_w4_all_discoveries.c
@@ -34,7 +34,7 @@
 #include "nci_state_impl.h"
 #include "nci_param_w4_all_discoveries.h"
 #include "nci_param_w4_host_select.h"
-#include "nci_util.h"
+#include "nci_util_p.h"
 
 typedef NciStateClass NciStateW4AllDiscoveriesClass;
 typedef struct nci_state_w4_all_discoveries {

--- a/src/nci_state_w4_host_select.c
+++ b/src/nci_state_w4_host_select.c
@@ -33,7 +33,7 @@
 #include "nci_sm.h"
 #include "nci_state_impl.h"
 #include "nci_param_w4_host_select.h"
-#include "nci_util.h"
+#include "nci_util_p.h"
 #include "nci_log.h"
 
 typedef NciStateClass NciStateW4HostSelectClass;

--- a/src/nci_util.c
+++ b/src/nci_util.c
@@ -974,7 +974,8 @@ nci_discovery_ntf_copy_array(
             if (src->param_len) {
                 size += G_ALIGN8(src->param_len);
                 if (src->param) {
-                    size += G_ALIGN8(sizeof(*src->param));
+                    size += G_ALIGN8(nci_mode_param_size(src->param,
+                        src->mode));
                 }
             }
         }
@@ -994,10 +995,16 @@ nci_discovery_ntf_copy_array(
                 ptr += G_ALIGN8(src->param_len);
                 if (src->param) {
                     NciModeParam* dest_param = (NciModeParam*)ptr;
+                    const gsize copied = nci_mode_param_copy_impl(dest_param,
+                        src->param, src->mode);
 
-                    *dest_param = *src->param;
-                    dest->param = dest_param;
-                    ptr += G_ALIGN8(sizeof(*src->param));
+                    if (copied) {
+                        dest->param = dest_param;
+                        ptr += G_ALIGN8(copied);
+                    } else {
+                        GWARN("ModeParam is not NULL but non copyable");
+                        dest->param = NULL;
+                    }
                 }
             }
         }

--- a/src/nci_util_p.h
+++ b/src/nci_util_p.h
@@ -1,6 +1,7 @@
 /*
  * Copyright (C) 2019-2020 Jolla Ltd.
  * Copyright (C) 2019-2020 Slava Monich <slava.monich@jolla.com>
+ * Copyright (C) 2020 Open Mobile Platform LLC.
  *
  * You may use this file under the terms of BSD license as follows:
  *
@@ -30,9 +31,10 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#ifndef NCI_UTIL_H
-#define NCI_UTIL_H
+#ifndef NCI_UTIL_PRIVATE_H
+#define NCI_UTIL_PRIVATE_H
 
+#include <nci_util.h>
 #include "nci_types_p.h"
 
 gboolean
@@ -76,7 +78,7 @@ nci_discovery_ntf_copy(
     const NciDiscoveryNtf* ntf)
     NCI_INTERNAL;
 
-#endif /* NCI_UTIL_H */
+#endif /* NCI_UTIL_PRIVATE_H */
 
 /*
  * Local Variables:

--- a/unit/nci_util/test_nci_util.c
+++ b/unit/nci_util/test_nci_util.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (C) 2019-2020 Jolla Ltd.
  * Copyright (C) 2019-2020 Slava Monich <slava.monich@jolla.com>
+ * Copyright (C) 2020 Open Mobile Platform LLC.
  *
  * You may use this file under the terms of BSD license as follows:
  *
@@ -32,7 +33,9 @@
 
 #include "test_common.h"
 
-#include "nci_util.h"
+#include "nci_util_p.h"
+
+#define FIELD_SIZEOF(t, f) (sizeof(((t*)0)->f))
 
 static TestOpt test_opt;
 
@@ -47,6 +50,8 @@ test_null(
 {
     g_assert(!nci_discovery_ntf_copy_array(NULL, 0));
     g_assert(!nci_discovery_ntf_copy(NULL));
+    g_assert(!nci_util_copy_mode_param(NULL, 0));
+    g_assert(!nci_util_copy_activation_param(NULL, 0, 0));
 }
 
 /*==========================================================================*
@@ -761,7 +766,7 @@ typedef struct test_discover_success_data {
     const char* name;
     GUtilData data;
     NciDiscoveryNtf ntf;
-    
+
 } TestDiscoverSuccessData;
 
 static
@@ -842,7 +847,7 @@ test_discover_copy_check(
     } else {
         g_assert(!n1->param_bytes);
     }
-    
+
     if (n2->param) {
         g_assert(n1->param);
         g_assert(!memcmp(n1->param_bytes, n2->param_bytes, n2->param_len));
@@ -930,6 +935,387 @@ static const TestDiscoverFailData discover_fail_tests[] = {
 };
 
 /*==========================================================================*
+ * copy_check helpers
+ *==========================================================================*/
+
+static
+void
+test_poll_a_copy_check(
+    const NciModeParamPollA* orig,
+    const NciModeParamPollA* copy)
+{
+    g_assert(orig);
+    g_assert(copy);
+    g_assert(orig != copy);
+    g_assert(orig->sel_res == copy->sel_res);
+    g_assert(orig->sel_res_len == copy->sel_res_len);
+    g_assert(orig->nfcid1_len == copy->nfcid1_len);
+    g_assert(orig->nfcid1_len == copy->nfcid1_len);
+    g_assert(!memcmp(orig->sens_res, copy->sens_res,
+        FIELD_SIZEOF(NciModeParamPollA, sens_res)));
+    g_assert(!memcmp(orig->nfcid1, copy->nfcid1,
+        FIELD_SIZEOF(NciModeParamPollA, nfcid1)));
+}
+
+static
+void
+test_poll_b_copy_check(
+    const NciModeParamPollB* orig,
+    const NciModeParamPollB* copy)
+{
+    g_assert(orig);
+    g_assert(copy);
+    g_assert(orig != copy);
+    g_assert(orig->fsc == copy->fsc);
+    g_assert(!memcmp(orig->nfcid0, copy->nfcid0,
+        FIELD_SIZEOF(NciModeParamPollB, nfcid0)));
+    g_assert(!memcmp(orig->app_data, copy->app_data,
+        FIELD_SIZEOF(NciModeParamPollB, app_data)));
+    g_assert(!orig->prot_info.bytes || orig->prot_info.size);
+    g_assert(!orig->prot_info.size || orig->prot_info.bytes);
+    g_assert(!copy->prot_info.bytes || copy->prot_info.size);
+    g_assert(!copy->prot_info.size || copy->prot_info.bytes);
+    if (orig->prot_info.bytes) {
+        g_assert(orig->prot_info.bytes != copy->prot_info.bytes);
+        g_assert(orig->prot_info.size == copy->prot_info.size);
+        g_assert(!memcmp(orig->prot_info.bytes, copy->prot_info.bytes,
+            orig->prot_info.size));
+    } else {
+        g_assert(orig->prot_info.bytes == copy->prot_info.bytes);
+    }
+}
+
+static
+void
+test_poll_f_copy_check(
+    const NciModeParamPollF* orig,
+    const NciModeParamPollF* copy)
+{
+    g_assert(orig);
+    g_assert(copy);
+    g_assert(orig != copy);
+    g_assert(orig->bitrate == copy->bitrate);
+    g_assert(!memcmp(orig->nfcid2, copy->nfcid2,
+        FIELD_SIZEOF(NciModeParamPollF, nfcid2)));
+}
+
+static
+void
+test_listen_f_copy_check(
+    const NciModeParamListenF* orig,
+    const NciModeParamListenF* copy)
+{
+    g_assert(orig);
+    g_assert(copy);
+    g_assert(orig != copy);
+    g_assert(!orig->nfcid2.bytes || orig->nfcid2.size);
+    g_assert(!orig->nfcid2.size || orig->nfcid2.bytes);
+    g_assert(!copy->nfcid2.bytes || copy->nfcid2.size);
+    g_assert(!copy->nfcid2.size || copy->nfcid2.bytes);
+    if (orig->nfcid2.bytes) {
+        g_assert(orig->nfcid2.bytes != copy->nfcid2.bytes);
+        g_assert(orig->nfcid2.size == copy->nfcid2.size);
+        g_assert(!memcmp(orig->nfcid2.bytes, copy->nfcid2.bytes,
+            orig->nfcid2.size));
+    } else {
+        g_assert(orig->nfcid2.bytes == copy->nfcid2.bytes);
+    }
+}
+
+static
+void
+test_mode_param_copy_check(
+    const NciModeParam* orig,
+    const NciModeParam* copy,
+    NCI_MODE mode)
+{
+    if (orig) {
+        g_assert(copy);
+        g_assert(orig != copy);
+        switch (mode) {
+        case NCI_MODE_ACTIVE_POLL_A:        /* fallthrough */
+        case NCI_MODE_PASSIVE_POLL_A:
+            test_poll_a_copy_check(&orig->poll_a, &copy->poll_a);
+            break;
+        case NCI_MODE_ACTIVE_POLL_F:        /* fallthrough */
+        case NCI_MODE_PASSIVE_POLL_F:
+            test_poll_f_copy_check(&orig->poll_f, &copy->poll_f);
+            break;
+        case NCI_MODE_PASSIVE_POLL_B:
+            test_poll_b_copy_check(&orig->poll_b, &copy->poll_b);
+            break;
+        case NCI_MODE_ACTIVE_LISTEN_F:
+        case NCI_MODE_PASSIVE_LISTEN_F:
+            test_listen_f_copy_check(&orig->listen_f, &copy->listen_f);
+            break;
+        case NCI_MODE_PASSIVE_POLL_15693:
+        case NCI_MODE_PASSIVE_LISTEN_15693:
+            break;
+        case NCI_MODE_PASSIVE_LISTEN_A:     /* fallthrough */
+        case NCI_MODE_PASSIVE_LISTEN_B:     /* fallthrough */
+        case NCI_MODE_ACTIVE_LISTEN_A:
+            break;
+        }
+    } else {
+        g_assert(orig == copy);
+    }
+}
+
+static
+void
+test_act_param_iso_dep_poll_a_copy_check(
+    const NciActivationParamIsoDepPollA* orig,
+    const NciActivationParamIsoDepPollA* copy)
+{
+    g_assert(orig);
+    g_assert(copy);
+    g_assert(orig != copy);
+    g_assert(orig->fsc == copy->fsc);
+    g_assert(orig->t0 == copy->t0);
+    g_assert(orig->ta == copy->ta);
+    g_assert(orig->tb == copy->tb);
+    g_assert(orig->tc == copy->tc);
+    g_assert(!orig->t1.bytes || orig->t1.size);
+    g_assert(!orig->t1.size || orig->t1.bytes);
+    g_assert(!copy->t1.bytes || copy->t1.size);
+    g_assert(!copy->t1.size || copy->t1.bytes);
+    if (orig->t1.bytes) {
+        g_assert(orig->t1.bytes != copy->t1.bytes);
+        g_assert(orig->t1.size == copy->t1.size);
+        g_assert(!memcmp(orig->t1.bytes, copy->t1.bytes, orig->t1.size));
+    } else {
+        g_assert(orig->t1.bytes == copy->t1.bytes);
+    }
+}
+
+static
+void
+test_act_param_iso_dep_poll_b_copy_check(
+    const NciActivationParamIsoDepPollB* orig,
+    const NciActivationParamIsoDepPollB* copy)
+{
+    g_assert(orig);
+    g_assert(copy);
+    g_assert(orig != copy);
+    g_assert(orig->mbli == copy->mbli);
+    g_assert(orig->did == copy->did);
+    g_assert(!orig->hlr.bytes || orig->hlr.size);
+    g_assert(!orig->hlr.size || orig->hlr.bytes);
+    g_assert(!copy->hlr.bytes || copy->hlr.size);
+    g_assert(!copy->hlr.size || copy->hlr.bytes);
+    if (orig->hlr.bytes) {
+        g_assert(orig->hlr.bytes != copy->hlr.bytes);
+        g_assert(orig->hlr.size == copy->hlr.size);
+        g_assert(!memcmp(orig->hlr.bytes, copy->hlr.bytes, orig->hlr.size));
+    } else {
+        g_assert(orig->hlr.bytes == copy->hlr.bytes);
+    }
+}
+
+static
+void
+test_act_param_nfc_dep_poll_copy_check(
+    const NciActivationParamNfcDepPoll* orig,
+    const NciActivationParamNfcDepPoll* copy)
+{
+    g_assert(orig);
+    g_assert(copy);
+    g_assert(orig != copy);
+    g_assert(orig->did == copy->did);
+    g_assert(orig->bs == copy->bs);
+    g_assert(orig->br == copy->br);
+    g_assert(orig->to == copy->to);
+    g_assert(orig->pp == copy->pp);
+    g_assert(!memcmp(orig->nfcid3, copy->nfcid3,
+        FIELD_SIZEOF(NciActivationParamNfcDepPoll, nfcid3)));
+    g_assert(!orig->g.bytes || orig->g.size);
+    g_assert(!orig->g.size || orig->g.bytes);
+    g_assert(!copy->g.bytes || copy->g.size);
+    g_assert(!copy->g.size || copy->g.bytes);
+    if (orig->g.bytes) {
+        g_assert(orig->g.bytes != copy->g.bytes);
+        g_assert(orig->g.size == copy->g.size);
+        g_assert(!memcmp(orig->g.bytes, copy->g.bytes, orig->g.size));
+    } else {
+        g_assert(orig->g.bytes == copy->g.bytes);
+    }
+}
+
+static
+void
+test_act_param_nfc_dep_listen_copy_check(
+    const NciActivationParamNfcDepListen* orig,
+    const NciActivationParamNfcDepListen* copy)
+{
+    g_assert(orig);
+    g_assert(copy);
+    g_assert(orig != copy);
+    g_assert(orig->did == copy->did);
+    g_assert(orig->bs == copy->bs);
+    g_assert(orig->br == copy->br);
+    g_assert(orig->pp == copy->pp);
+    g_assert(!memcmp(orig->nfcid3, copy->nfcid3,
+        FIELD_SIZEOF(NciActivationParamNfcDepPoll, nfcid3)));
+    g_assert(!orig->g.bytes || orig->g.size);
+    g_assert(!orig->g.size || orig->g.bytes);
+    g_assert(!copy->g.bytes || copy->g.size);
+    g_assert(!copy->g.size || copy->g.bytes);
+    if (orig->g.bytes) {
+        g_assert(orig->g.bytes != copy->g.bytes);
+        g_assert(orig->g.size == copy->g.size);
+        g_assert(!memcmp(orig->g.bytes, copy->g.bytes, orig->g.size));
+    } else {
+        g_assert(orig->g.bytes == copy->g.bytes);
+    }
+}
+
+static
+void
+test_activation_param_copy_check(
+    const NciActivationParam* orig,
+    const NciActivationParam* copy,
+    NCI_RF_INTERFACE intf,
+    NCI_MODE mode)
+{
+    if (orig) {
+        g_assert(copy);
+        g_assert(orig != copy);
+        switch (intf) {
+        case NCI_RF_INTERFACE_ISO_DEP:
+            switch (mode) {
+            case NCI_MODE_PASSIVE_POLL_A:
+            case NCI_MODE_ACTIVE_POLL_A:
+                test_act_param_iso_dep_poll_a_copy_check(&orig->iso_dep_poll_a,
+                    &copy->iso_dep_poll_a);
+                break;
+            case NCI_MODE_PASSIVE_POLL_B:
+                test_act_param_iso_dep_poll_b_copy_check(&orig->iso_dep_poll_b,
+                    &copy->iso_dep_poll_b);
+            case NCI_MODE_PASSIVE_POLL_F:
+            case NCI_MODE_ACTIVE_POLL_F:
+            case NCI_MODE_PASSIVE_POLL_15693:
+            case NCI_MODE_PASSIVE_LISTEN_A:
+            case NCI_MODE_PASSIVE_LISTEN_B:
+            case NCI_MODE_PASSIVE_LISTEN_F:
+            case NCI_MODE_ACTIVE_LISTEN_A:
+            case NCI_MODE_ACTIVE_LISTEN_F:
+            case NCI_MODE_PASSIVE_LISTEN_15693:
+                break;
+            }
+            break;
+        case NCI_RF_INTERFACE_FRAME:
+            /* There are no Activation Parameters for Frame RF interface */
+            break;
+        case NCI_RF_INTERFACE_NFC_DEP:
+            switch (mode) {
+            case NCI_MODE_ACTIVE_POLL_A:
+            case NCI_MODE_ACTIVE_POLL_F:
+            case NCI_MODE_PASSIVE_POLL_A:
+            case NCI_MODE_PASSIVE_POLL_F:
+                test_act_param_nfc_dep_poll_copy_check(&orig->nfc_dep_poll,
+                    &copy->nfc_dep_poll);
+            case NCI_MODE_ACTIVE_LISTEN_A:
+            case NCI_MODE_ACTIVE_LISTEN_F:
+            case NCI_MODE_PASSIVE_LISTEN_A:
+            case NCI_MODE_PASSIVE_LISTEN_F:
+                test_act_param_nfc_dep_listen_copy_check(&orig->nfc_dep_listen,
+                    &copy->nfc_dep_listen);
+            case NCI_MODE_PASSIVE_POLL_B:
+            case NCI_MODE_PASSIVE_POLL_15693:
+            case NCI_MODE_PASSIVE_LISTEN_B:
+            case NCI_MODE_PASSIVE_LISTEN_15693:
+                break;
+            }
+            break;
+        case NCI_RF_INTERFACE_NFCEE_DIRECT:
+        case NCI_RF_INTERFACE_PROPRIETARY:
+            break;
+        }
+    } else {
+        g_assert(orig == copy);
+    }
+}
+
+/*==========================================================================*
+ * mode_param_copy
+ *==========================================================================*/
+
+static
+void
+test_mode_param_copy(
+    gconstpointer test_data)
+{
+    const TestModeParamSuccessData* test = test_data;
+    const NCI_MODE mode = test->mode;
+    NciModeParam param;
+    memset(&param, 0, sizeof(param));
+    g_assert(nci_parse_mode_param(&param, mode, test->data.bytes,
+        test->data.size));
+
+    NciModeParam* copy = nci_util_copy_mode_param(&param, mode);
+    test_mode_param_copy_check(&param, copy, mode);
+    g_free(copy);
+}
+
+/*==========================================================================*
+ * discover_mode_param_copy
+ *==========================================================================*/
+
+static
+void
+test_discover_mode_param_copy(
+    gconstpointer test_data)
+{
+    const TestDiscoverSuccessData* test = test_data;
+    const NciModeParam* orig = test->ntf.param;
+    const NCI_MODE mode = test->ntf.mode;
+    NciModeParam* copy = nci_util_copy_mode_param(orig, mode);
+
+    test_mode_param_copy_check(orig, copy, mode);
+    g_free(copy);
+
+    orig = NULL;
+    copy = nci_util_copy_mode_param(orig, mode);
+    test_mode_param_copy_check(orig, copy, mode);
+    g_free(copy);
+}
+
+/*==========================================================================*
+ * intf_activated_copy_params
+ *==========================================================================*/
+
+
+static
+void
+test_intf_activated_copy_params(
+    gconstpointer test_data)
+{
+    const TestIntfActivatedSuccessData* test = test_data;
+    NciIntfActivationNtf ntf;
+    NciModeParam mode_param;
+    NciActivationParam activation_param;
+
+    memset(&mode_param, 0, sizeof(mode_param));
+    memset(&activation_param, 0, sizeof(activation_param));
+    g_assert(nci_parse_intf_activated_ntf(&ntf, &mode_param, &activation_param,
+        test->data.bytes, test->data.size));
+
+    const NciModeParam* orig_mode = test->mode_param;
+    const NCI_MODE mode = ntf.mode;
+    const NCI_RF_INTERFACE intf = ntf.rf_intf;
+    const NciActivationParam* orig_act = test->activation_param;
+    NciModeParam* copy_mode = nci_util_copy_mode_param(orig_mode, mode);
+    NciActivationParam* copy_act = nci_util_copy_activation_param(orig_act, intf,
+        mode);
+
+    test_mode_param_copy_check(orig_mode, copy_mode, mode);
+    test_activation_param_copy_check(orig_act, copy_act, intf, mode);
+    g_free(copy_mode);
+    g_free(copy_act);
+}
+
+
+/*==========================================================================*
  * Common
  *==========================================================================*/
 
@@ -945,10 +1331,14 @@ int main(int argc, char* argv[])
     g_test_add_func(TEST_("listen_mode"), test_listen_mode);
     for (i = 0; i < G_N_ELEMENTS(mode_param_success_tests); i++) {
         const TestModeParamSuccessData* test = mode_param_success_tests + i;
-        char* path = g_strconcat(TEST_("mode_param/ok/"), test->name, NULL);
+        char* path1 = g_strconcat(TEST_("mode_param/ok/"), test->name, NULL);
+        char* path2 = g_strconcat(TEST_("mode_param/ok_copy/"), test->name,
+            NULL);
 
-        g_test_add_data_func(path, test, test_mode_param_success);
-        g_free(path);
+        g_test_add_data_func(path1, test, test_mode_param_success);
+        g_test_add_data_func(path2, test, test_mode_param_copy);
+        g_free(path1);
+        g_free(path2);
     }
     for (i = 0; i < G_N_ELEMENTS(mode_param_fail_tests); i++) {
         const TestModeParamFailData* test = mode_param_fail_tests + i;
@@ -961,20 +1351,28 @@ int main(int argc, char* argv[])
         const TestDiscoverSuccessData* test = discover_success_tests + i;
         char* path1 = g_strconcat(TEST_("discover/success/"), test->name, NULL);
         char* path2 = g_strconcat(TEST_("discover/copy/"), test->name, NULL);
+        char* path3 = g_strconcat(TEST_("discover/copy_mode_param/"),
+            test->name, NULL);
 
         g_test_add_data_func(path1, test, test_discover_success);
         g_test_add_data_func(path2, test, test_discover_copy);
+        g_test_add_data_func(path3, test, test_discover_mode_param_copy);
         g_free(path1);
         g_free(path2);
+        g_free(path3);
     }
     for (i = 0; i < G_N_ELEMENTS(intf_activated_success_tests); i++) {
         const TestIntfActivatedSuccessData* test =
             intf_activated_success_tests + i;
-        char* path = g_strconcat(TEST_("intf_activated/success/"),
+        char* path1 = g_strconcat(TEST_("intf_activated/success/"),
+            test->name, NULL);
+        char* path2 = g_strconcat(TEST_("intf_activated/copy_params/"),
             test->name, NULL);
 
-        g_test_add_data_func(path, test, test_intf_activated_success);
-        g_free(path);
+        g_test_add_data_func(path1, test, test_intf_activated_success);
+        g_test_add_data_func(path2, test, test_intf_activated_copy_params);
+        g_free(path1);
+        g_free(path2);
     }
     for (i = 0; i < G_N_ELEMENTS(intf_activated_fail_tests); i++) {
         const TestIntfActivatedFailData* test = intf_activated_fail_tests + i;


### PR DESCRIPTION
Now we are able to make deep copy of NciModeParam and NciActivationParam structs.

Also copy bug was fixed for nci_discovery_ntf_copy() when copied object had some
pointers from source.