### PR TITLE
Introducing configuration file

### DIFF
--- a/README
+++ b/README
@@ -16,3 +16,11 @@ as well as a limited subset of NCI 2.0 features.
 This library doesn't provide any hardware access methods. It's up to
 the code linking with this library to implement interfaces described
 by nci_hal.h
+
+Optionally, NFC technologies supported by the chip can be specified
+in /etc/libncicore.conf file, e.g.
+
+  [Configuration]
+  Technologies = A,B,F
+
+By default all technologies are assumed to be supported.

--- a/rpm/libncicore.spec
+++ b/rpm/libncicore.spec
@@ -6,7 +6,7 @@ License: BSD
 URL: https://github.com/mer-hybris/libncicore
 Source: %{name}-%{version}.tar.bz2
 BuildRequires:  pkgconfig(glib-2.0)
-BuildRequires:  pkgconfig(libglibutil)
+BuildRequires:  pkgconfig(libglibutil) >= 1.0.29
 Requires(post): /sbin/ldconfig
 Requires(postun): /sbin/ldconfig
 

--- a/src/nci_sm.c
+++ b/src/nci_sm.c
@@ -1034,6 +1034,7 @@ nci_sm_object_init(
 
     /* Only poll modes by default */
     sm->op_mode = NFC_OP_MODE_RW | NFC_OP_MODE_PEER | NFC_OP_MODE_POLL;
+    sm->options = NCI_OPTIONS_DEFAULT;
     self->transitions = g_ptr_array_new_with_free_func((GDestroyNotify)
         nci_transition_unref);
     self->states = g_ptr_array_new_full(NCI_CORE_STATES, (GDestroyNotify)

--- a/src/nci_sm.c
+++ b/src/nci_sm.c
@@ -97,6 +97,29 @@ static guint nci_sm_signals[SIGNAL_COUNT] = { 0 };
 
 #define NCI_IS_INTERNAL_STATE(state) ((state) < NCI_RFST_IDLE)
 
+/* Config file name is extern for unit tests */
+const char* nci_sm_config_file = "/etc/libncicore.conf";
+static const char CONFIG_SECTION[] = "Configuration";
+static const char CONFIG_LIST_SEPARATORS[] = ";,";
+static const char CONFIG_ENTRY_TECHNOLOGIES[] = "Technologies";
+static const char CONFIG_TECHNOLOGY_TYPE_A[] = "A";
+static const char CONFIG_TECHNOLOGY_TYPE_B[] = "B";
+static const char CONFIG_TECHNOLOGY_TYPE_F[] = "F";
+static const char CONFIG_TECHNOLOGY_TYPE_V[] = "V";
+static const char CONFIG_TECHNOLOGY_POLL_A[] = "Poll-A";
+static const char CONFIG_TECHNOLOGY_POLL_B[] = "Poll-B";
+static const char CONFIG_TECHNOLOGY_POLL_F[] = "Poll-F";
+static const char CONFIG_TECHNOLOGY_POLL_V[] = "Poll-V";
+static const char CONFIG_TECHNOLOGY_LISTEN_A[] = "Listen-A";
+static const char CONFIG_TECHNOLOGY_LISTEN_B[] = "Listen-B";
+static const char CONFIG_TECHNOLOGY_LISTEN_F[] = "Listen-F";
+static const char CONFIG_TECHNOLOGY_LISTEN_V[] = "Listen-V";
+
+typedef struct nci_technolofy_option {
+    const char* name;
+    NCI_OPTIONS opt;
+} NciTechnologyOption;
+
 static inline NciSmObject* nci_sm_object(NciSm* sm) /* NULL safe */
     { return G_LIKELY(sm) ? NCI_SM(G_CAST(sm, NciSmObject, sm)) : NULL; }
 
@@ -398,6 +421,82 @@ nci_sm_add_signal_handler(
     return 0;
 }
 
+static
+void
+nci_sm_parse_config(
+    NciSm* sm,
+    GKeyFile* config)
+{
+    char* sval = g_key_file_get_string(config, CONFIG_SECTION,
+        CONFIG_ENTRY_TECHNOLOGIES, NULL);
+
+    if (sval) {
+        static const NciTechnologyOption nci_tech_options[] = {
+            /* A and B are always enabled */
+            { CONFIG_TECHNOLOGY_TYPE_A, NCI_OPTION_NONE },
+            { CONFIG_TECHNOLOGY_TYPE_B, NCI_OPTION_NONE },
+            { CONFIG_TECHNOLOGY_TYPE_F, NCI_OPTION_TYPE_F },
+            { CONFIG_TECHNOLOGY_TYPE_V, NCI_OPTION_TYPE_V },
+            { CONFIG_TECHNOLOGY_POLL_A, NCI_OPTION_NONE },
+            { CONFIG_TECHNOLOGY_POLL_B, NCI_OPTION_NONE },
+            { CONFIG_TECHNOLOGY_POLL_F, NCI_OPTION_POLL_F },
+            { CONFIG_TECHNOLOGY_POLL_V, NCI_OPTION_POLL_V },
+            { CONFIG_TECHNOLOGY_LISTEN_A, NCI_OPTION_NONE },
+            { CONFIG_TECHNOLOGY_LISTEN_B, NCI_OPTION_NONE },
+            { CONFIG_TECHNOLOGY_LISTEN_F, NCI_OPTION_LISTEN_F },
+            { CONFIG_TECHNOLOGY_LISTEN_V, NCI_OPTION_LISTEN_V }
+        };
+
+        char** techs = g_strsplit_set(sval, CONFIG_LIST_SEPARATORS, -1);
+        char** val = techs;
+
+        sm->options = NCI_OPTION_NONE;
+        for (val = techs; *val; val++) {
+            const NciTechnologyOption* opt = NULL;
+            guint i;
+
+            g_strstrip(*val);
+            for (i = 0; i < G_N_ELEMENTS(nci_tech_options); i++) {
+                if (!g_ascii_strcasecmp(*val, nci_tech_options[i].name)) {
+                    opt = nci_tech_options + i;
+                    break;
+                }
+            }
+
+            if (opt) {
+                GDEBUG("  %s", opt->name);
+                sm->options |= opt->opt;
+            } else {
+                GWARN("Unexpected technology '%s' in configuration", *val);
+            }
+        }
+        g_strfreev(techs);
+        g_free(sval);
+    }
+}
+
+static
+void
+nci_sm_load_config(
+    NciSm* sm)
+{
+    if (nci_sm_config_file &&
+        g_file_test(nci_sm_config_file, G_FILE_TEST_EXISTS)) {
+        GError* error = NULL;
+        GKeyFile* config = g_key_file_new();
+
+        if (g_key_file_load_from_file(config, nci_sm_config_file,
+            G_KEY_FILE_NONE, &error)) {
+            GDEBUG("Parsing %s", nci_sm_config_file);
+            nci_sm_parse_config(sm, config);
+        } else {
+            GERR("Error loading %s: %s", nci_sm_config_file, error->message);
+            g_error_free(error);
+        }
+        g_key_file_unref(config);
+    }
+}
+
 /*==========================================================================*
  * Interface
  *==========================================================================*/
@@ -639,6 +738,8 @@ nci_sm_new(
     /* And these are not reusable */
     nci_sm_add_new_transition(sm, NCI_RFST_IDLE,
         nci_transition_idle_to_discovery_new);
+
+    nci_sm_load_config(sm);
     return sm;
 }
 

--- a/src/nci_sm.h
+++ b/src/nci_sm.h
@@ -47,9 +47,8 @@ typedef enum nci_options {
     NCI_OPTION_NONE                     = 0x00,
     NCI_OPTION_POLL_F                   = 0x01,
     NCI_OPTION_LISTEN_F                 = 0x02,
-    NCI_OPTION_LISTEN_F_NFC_DEP         = 0x04,
-    NCI_OPTION_POLL_V                   = 0x08,
-    NCI_OPTION_LISTEN_V                 = 0x10
+    NCI_OPTION_POLL_V                   = 0x04,
+    NCI_OPTION_LISTEN_V                 = 0x08
 } NCI_OPTIONS;
 
 #define NCI_OPTION_TYPE_F   (NCI_OPTION_POLL_F|NCI_OPTION_LISTEN_F)
@@ -456,6 +455,10 @@ nci_sm_handle_rf_deactivate_ntf(
     NciSm* sm,
     const GUtilData* payload)
     NCI_INTERNAL;
+
+/* And this one is currently only for unit tests */
+
+extern const char* nci_sm_config_file NCI_INTERNAL;
 
 #endif /* NCI_STATE_MACHINE_H */
 

--- a/src/nci_sm.h
+++ b/src/nci_sm.h
@@ -52,6 +52,10 @@ typedef enum nci_options {
     NCI_OPTION_LISTEN_V                 = 0x10
 } NCI_OPTIONS;
 
+#define NCI_OPTION_TYPE_F   (NCI_OPTION_POLL_F|NCI_OPTION_LISTEN_F)
+#define NCI_OPTION_TYPE_V   (NCI_OPTION_POLL_V|NCI_OPTION_LISTEN_V)
+#define NCI_OPTIONS_DEFAULT NCI_OPTION_TYPE_F
+
 /* Table 9: NFCC Features */
 typedef enum nci_nfcc_discovery {
     NCI_NFCC_DISCOVERY_NONE             = 0x00,

--- a/unit/nci_core/test_nci_core.c
+++ b/unit/nci_core/test_nci_core.c
@@ -37,6 +37,7 @@
 #include "nci_sm.h"
 
 #include <gutil_macros.h>
+#include <gutil_misc.h>
 #include <gutil_log.h>
 
 #include <glib-object.h> /* For g_type_init() */
@@ -44,7 +45,11 @@
 static TestOpt test_opt;
 
 #define TEST_DEFAULT_CMD_TIMEOUT (10000) /* milliseconds */
+#define TEST_SHORT_TIMEOUT (500) /* milliseconds */
 
+static const guint8 CORE_RESET_CMD[] = {
+    0x20, 0x00, 0x01, 0x00
+};
 static const guint8 CORE_RESET_RSP[] = {
     0x40, 0x00, 0x03, 0x00, 0x10, 0x00
 };
@@ -63,6 +68,12 @@ static const guint8 CORE_RESET_V2_NTF[] = {
 };
 static const guint8 CORE_RESET_RSP_BROKEN[] = {
     0x40, 0x00, 0x02, 0x00, 0x00
+};
+static const guint8 CORE_INIT_CMD_V1[] = {
+    0x20, 0x01, 0x00
+};
+static const guint8 CORE_INIT_CMD_V2[] = {
+    0x20, 0x01, 0x02, 0x00, 0x00
 };
 static const guint8 CORE_INIT_RSP[] = {
     0x40, 0x01, 0x19, 0x00, 0x03, 0x0e, 0x02, 0x00,
@@ -116,16 +127,24 @@ static const guint8 CORE_INIT_V2_RSP_BROKEN2[] = {
 static const guint8 CORE_INIT_RSP_BROKEN[] = {
     0x40, 0x01, 0x00
 };
+static const guint8 CORE_GET_CONFIG_CMD[] = {
+    0x20, 0x03, 0x02, 0x01, 0x00
+};
 static const guint8 CORE_GET_CONFIG_RSP[] = {
-    0x40, 0x03, 0x0c, 0x00, 0x03, 0x00, 0x02, 0xfa,
-    0x00, 0x18, 0x01, 0x01, 0x50, 0x01, 0x02
+    0x40, 0x03, 0x06, 0x00, 0x01, 0x00, 0x02, 0xfa,
+    0x00
 };
 static const guint8 CORE_GET_CONFIG_RSP_DEFAULT_DURATION[] = {
-    0x40, 0x03, 0x0c, 0x00, 0x03, 0x00, 0x02, 0xf4,
-    0x01, 0x18, 0x01, 0x01, 0x50, 0x01, 0x02
+    0x40, 0x03, 0x06, 0x00, 0x01, 0x00, 0x02, 0xf4,
+    0x01
+};
+static const guint8 CORE_GET_CONFIG_RSP_DEFAULT_DURATION_EXTRA[] = {
+    0x40, 0x03, 0x09, 0x00, 0x02, 0x50, 0x01, 0x02,
+    0x00, 0x02, 0xf4, 0x01
 };
 static const guint8 CORE_GET_CONFIG_RSP_WRONG_DURATION[] = {
-    0x40, 0x03, 0x06, 0x00, 0x01, 0x00, 0x02, 0xe8, 0x03
+    0x40, 0x03, 0x06, 0x00, 0x01, 0x00, 0x02, 0xe8,
+    0x03
 };
 static const guint8 CORE_GET_CONFIG_RSP_BROKEN_DURATION_1[] = {
     0x40, 0x03, 0x05, 0x00, 0x01, 0x00, 0x02, 0xf4
@@ -145,11 +164,30 @@ static const guint8 CORE_GET_CONFIG_RSP_INVALID_PARAM[] = {
 static const guint8 CORE_GET_CONFIG_BROKEN[] = {
     0x40, 0x03, 0x00
 };
+static const guint8 CORE_SET_CONFIG_CMD[] = {
+    0x20, 0x02, 0x0b, 0x03, 0x00, 0x02, 0xf4, 0x01,
+    0x08, 0x01, 0x00, 0x11, 0x01, 0x00
+};
 static const guint8 CORE_SET_CONFIG_RSP[] = {
     0x40, 0x02, 0x02, 0x00, 0x00
 };
 static const guint8 CORE_SET_CONFIG_RSP_ERROR[] = {
     0x40, 0x02, 0x02, NCI_STATUS_REJECTED, 0x00
+};
+static const guint8 RF_SET_LISTEN_MODE_ROUTING_CMD_TECHNOLOGY_A_B_F[] = {
+    0x21, 0x01, 0x11, 0x00, 0x03, 0x00, 0x03, 0x00,
+    0x01, 0x00, 0x00, 0x03, 0x00, 0x01, 0x01, 0x00,
+    0x03, 0x00, 0x01, 0x02
+};
+static const guint8 RF_SET_LISTEN_MODE_ROUTING_CMD_PROTOCOL_A_B_F[] = {
+    0x21, 0x01, 0x1b, 0x00, 0x05, 0x01, 0x03, 0x00,
+    0x01, 0x01, 0x01, 0x03, 0x00, 0x01, 0x02, 0x01,
+    0x03, 0x00, 0x01, 0x04, 0x01, 0x03, 0x00, 0x01,
+    0x03, 0x01, 0x03, 0x00, 0x01, 0x05
+};
+static const guint8 RF_SET_LISTEN_MODE_ROUTING_CMD_PROTOCOL_ISODEP[] = {
+    0x21, 0x01, 0x07, 0x00, 0x01, 0x01, 0x03, 0x00,
+    0x01, 0x04
 };
 static const guint8 RF_SET_LISTEN_MODE_ROUTING_RSP[] = {
     0x41, 0x01, 0x01, 0x00
@@ -160,6 +198,23 @@ static const guint8 RF_SET_LISTEN_MODE_ROUTING_RSP_ERROR[] = {
 static const guint8 RF_SET_LISTEN_MODE_ROUTING_RSP_BROKEN[] = {
     0x41, 0x01, 0x00
 };
+static const guint8 RF_DISCOVER_MAP_CMD_A_B_F[] = {
+    0x21, 0x00, 0x10, 0x05, 0x01, 0x01, 0x01, 0x02,
+    0x01, 0x01, 0x04, 0x01, 0x02, 0x03, 0x01, 0x01,
+    0x05, 0x01, 0x03
+};
+static const guint8 RF_DISCOVER_MAP_CMD_A_B_F_NFCDEP[] = {
+    0x21, 0x00, 0x16, 0x07, 0x01, 0x01, 0x01, 0x02,
+    0x01, 0x01, 0x04, 0x01, 0x02, 0x03, 0x01, 0x01,
+    0x05, 0x01, 0x03, 0x05, 0x02, 0x03, 0x04, 0x02,
+    0x02
+};
+static const guint8 RF_DISCOVER_MAP_CMD_NFCDEP[] = {
+    0x21, 0x00, 0x04, 0x01, 0x05, 0x02, 0x03
+};
+static const guint8 RF_DISCOVER_MAP_CMD_LISTEN_ISODEP[] = {
+    0x21, 0x00, 0x04, 0x01, 0x04, 0x02, 0x02
+};
 static const guint8 RF_DISCOVER_MAP_RSP[] = {
     0x41, 0x00, 0x01, 0x00
 };
@@ -168,6 +223,23 @@ static const guint8 RF_DISCOVER_MAP_ERROR[] = {
 };
 static const guint8 RF_DISCOVER_MAP_BROKEN[] = {
     0x41, 0x00, 0x00
+};
+static const guint8 RF_DISCOVER_CMD_A_B_F[] = {
+    0x21, 0x03, 0x0b, 0x05, 0x01, 0x01, 0x00, 0x01,
+    0x03, 0x01, 0x02, 0x01, 0x05, 0x01
+};
+static const guint8 RF_DISCOVER_CMD_A_B_F_NFCDEP[] = {
+    0x21, 0x03, 0x15, 0x0a, 0x01, 0x01, 0x00, 0x01,
+    0x03, 0x01, 0x02, 0x01, 0x05, 0x01, 0x82, 0x01,
+    0x85, 0x01, 0x80, 0x01, 0x83, 0x01, 0x81, 0x01
+};
+static const guint8 RF_DISCOVER_CMD_NFCDEP[] = {
+    0x21, 0x03, 0x09, 0x04, 0x82, 0x01, 0x85, 0x01,
+    0x80, 0x01, 0x83, 0x01
+};
+static const guint8 RF_DISCOVER_CMD_A_B_LISTEN[] = {
+    0x21, 0x03, 0x07, 0x03, 0x80, 0x01, 0x83, 0x01,
+    0x81, 0x01
 };
 static const guint8 RF_DISCOVER_RSP[] = {
     0x41, 0x03, 0x01, 0x00
@@ -184,7 +256,7 @@ static const guint8 RF_INTF_ACTIVATED_NTF_T2[] = {
     0x4a, 0xeb, 0x2b, 0x80, 0x01, 0x00, 0x00, 0x00,
     0x00, 0x00
 };
-static const guint8 RF_INTF_ACTIVATED_NTF_ISO_DEP[] = {
+static const guint8 RF_INTF_ACTIVATED_NTF_ISODEP[] = {
     0x61, 0x05, 0x1f, 0x01, 0x02, 0x04, 0x00, 0xff,
     0x01, 0x09, 0x04, 0x00, 0x04, 0x4f, 0x01, 0x74,
     0x01, 0x01, 0x20, 0x00, 0x00, 0x00, 0x0b, 0x0a,
@@ -232,7 +304,7 @@ static const guint8 RF_INTF_ACTIVATED_NTF_T4A_BROKEN_ACT_PARAM2[] = {
     0x01, 0x09, 0x04, 0x00, 0x04, 0x37, 0xf4, 0x95,
     0x95, 0x01, 0x20, 0x00, 0x00, 0x00, 0x01, 0x00 /* Missing params */,
 };
-static const guint8 RF_INTF_ACTIVATED_NTF_NFC_DEP_LISTEN_A[] = {
+static const guint8 RF_INTF_ACTIVATED_NTF_NFCDEP_LISTEN_A[] = {
     0x61, 0x05, 0x2e, 0x01, 0x03, 0x05, 0x83, 0xfb,
     0x01, 0x00, 0x85, 0x02, 0x02, 0x23, 0x22, 0x10,
     0x5a, 0x37, 0xa5, 0x7b, 0x88, 0x6e, 0x6e, 0xef,
@@ -244,6 +316,12 @@ static const guint8 RF_INTF_ACTIVATED_NTF_NFC_DEP_LISTEN_A[] = {
 static const guint8 RF_INTF_ACTIVATED_NTF_CE_A[] = {
     0x61, 0x05, 0x0c, 0x01, 0x02, 0x04, 0x80, 0xff,
     0x01, 0x00, 0x80, 0x00, 0x00, 0x01, 0x80
+};
+static const guint8 RF_DEACTIVATE_IDLE_CMD[] = {
+    0x21, 0x06, 0x01, 0x00
+};
+static const guint8 RF_DEACTIVATE_DISCOVERY_CMD[] = {
+    0x21, 0x06, 0x01, 0x03
 };
 static const guint8 RF_DEACTIVATE_RSP[] = {
     0x41, 0x06, 0x01, 0x00
@@ -320,9 +398,14 @@ static const guint8 RF_IGNORED_NTF[] = {
 static const guint8 NFCEE_IGNORED_NTF[] = {
     0x62, 0x33, 0x00
 };
-static const guint8 RF_DISCOVER_NTF_1_ISO_DEP[] = {
+static const guint8 RF_DISCOVER_NTF_1_ISODEP[] = {
     0x61, 0x03, 0x0e, 0x01, 0x04, 0x00, 0x09, 0x04,
     0x00, 0x04, 0x4f, 0x01, 0x74, 0x01, 0x01, 0x20,
+    0x02
+};
+static const guint8 RF_DISCOVER_NTF_1_T2T[] = {
+    0x61, 0x03, 0x0e, 0x01, 0x02, 0x00, 0x09, 0x04,
+    0x00, 0x04, 0x4f, 0x01, 0x74, 0x01, 0x01, 0x08,
     0x02
 };
 static const guint8 RF_DISCOVER_NTF_2_T2T[] = {
@@ -344,6 +427,12 @@ static const guint8 RF_DISCOVER_NTF_3_PROPRIETARY_LAST[] = {
     0x61, 0x03, 0x0e, 0x03, 0x81, 0x00, 0x09, 0x04,
     0x00, 0x04, 0x4f, 0x01, 0x74, 0x01, 0x01, 0x08,
     0x00
+};
+static const guint8 RF_DISCOVER_SELECT_1_T2T_CMD[] = {
+    0x21, 0x04, 0x03, 0x01, 0x02, 0x01
+};
+static const guint8 RF_DISCOVER_SELECT_1_ISODEP_CMD[] = {
+    0x21, 0x04, 0x03, 0x01, 0x04, 0x02
 };
 static const guint8 RF_DISCOVER_SELECT_RSP[] = {
     0x41, 0x04, 0x01, 0x00
@@ -425,13 +514,14 @@ static NciHalIo test_dummy_hal_io = {
 typedef struct test_hal_io {
     NciHalIo io;
     GPtrArray* read_queue;
-    GPtrArray* written;
+    GPtrArray* cmd_expected;
     guint write_id;
     guint read_id;
     NciHalClient* sar;
     void* test_data;
     guint fail_write;
     guint rsp_expected;
+    GMainLoop* write_flush_loop;
 } TestHalIo;
 
 typedef struct test_hal_io_read {
@@ -542,6 +632,26 @@ test_hal_io_read_cb(
 }
 
 static
+void
+test_dump_bytes(
+    char dir,
+    GBytes* bytes)
+{
+    gsize len;
+    const guint8* data = g_bytes_get_data(bytes, &len);
+    char buf[GUTIL_HEXDUMP_BUFSIZE];
+
+    while (len > 0) {
+        const guint consumed = gutil_hexdump(buf, data, len);
+
+        gutil_log(NULL, GLOG_LEVEL_DEBUG, "%c %s", dir, buf);
+        data += consumed;
+        len -= consumed;
+        dir = ' ';
+    }
+}
+
+static
 gboolean
 test_hal_io_write_cb(
     gpointer user_data)
@@ -550,14 +660,34 @@ test_hal_io_write_cb(
     TestHalIo* hal = write->hal;
 
     g_assert(hal->write_id);
+    if (hal->cmd_expected->len) {
+        GBytes* expected = hal->cmd_expected->pdata[0];
+
+        if (!g_bytes_equal(expected, write->bytes)) {
+            GDEBUG("Unexpected write:");
+            test_dump_bytes('<', write->bytes);
+            GDEBUG("Doesn't match this:");
+            test_dump_bytes('<', expected);
+            g_assert_not_reached();
+        }
+        g_ptr_array_remove_index(hal->cmd_expected, 0);
+    } else {
+        GDEBUG("Unchecked write");
+        test_dump_bytes('<', write->bytes);
+    }
+
     hal->write_id = 0;
     hal->rsp_expected++;
-    g_ptr_array_add(hal->written, g_bytes_ref(write->bytes));
     if (write->complete) {
         write->complete(hal->sar, TRUE);
     }
     if (!hal->read_id) {
         hal->read_id = g_idle_add(test_hal_io_read_cb, hal);
+    }
+    if (!hal->write_id && hal->write_flush_loop) {
+        GDEBUG("Unblocking flush waiter");
+        test_quit_later(hal->write_flush_loop);
+        hal->write_flush_loop = NULL;
     }
     return G_SOURCE_REMOVE;
 }
@@ -655,8 +785,8 @@ test_hal_io_new_with_functions(
     TestHalIo* hal = g_new0(TestHalIo, 1);
 
     hal->io.fn = fn;
-    hal->written = g_ptr_array_new();
-    g_ptr_array_set_free_func(hal->written, test_bytes_unref);
+    hal->cmd_expected = g_ptr_array_new();
+    g_ptr_array_set_free_func(hal->cmd_expected, test_bytes_unref);
     return hal;
 }
 
@@ -711,7 +841,8 @@ test_hal_io_free(
 {
     g_assert(!hal->sar);
     g_assert(!hal->write_id);
-    g_ptr_array_free(hal->written, TRUE);
+    g_assert(!hal->cmd_expected->len);
+    g_ptr_array_free(hal->cmd_expected, TRUE);
     if (hal->read_queue) {
         g_ptr_array_free(hal->read_queue, TRUE);
     }
@@ -783,18 +914,33 @@ test_restart(
     test_hal_io_queue_rsp(hal, CORE_RESET_RSP);
     test_hal_io_queue_ntf(hal, CORE_IGNORED_NTF);
     test_hal_io_queue_rsp(hal, CORE_INIT_RSP);
-    test_hal_io_queue_rsp(hal, CORE_GET_CONFIG_RSP);
-    test_hal_io_queue_rsp(hal, CORE_SET_CONFIG_RSP);
+    test_hal_io_queue_rsp(hal, CORE_GET_CONFIG_RSP_DEFAULT_DURATION);
 
     id = nci_core_add_current_state_changed_handler(nci,
         test_restart_done, loop);
-
     nci_core_restart(nci);
     test_run_loop(&test_opt, loop);
+    nci_core_remove_handler(nci, id);
 
     g_assert(nci->current_state == NCI_RFST_IDLE);
     g_assert(nci->next_state == NCI_RFST_IDLE);
+
+    /* Again with a cancel */
+    nci_core_set_state(nci, NCI_RFST_DISCOVERY);
+    GDEBUG("Starting all over again");
+    nci_core_restart(nci); /* Cancels the above request */
+    test_hal_io_queue_rsp(hal, CORE_RESET_RSP);
+    test_hal_io_queue_ntf(hal, CORE_IGNORED_NTF);
+    test_hal_io_queue_rsp(hal, CORE_INIT_RSP);
+    test_hal_io_queue_rsp(hal, CORE_GET_CONFIG_RSP_DEFAULT_DURATION);
+
+    id = nci_core_add_current_state_changed_handler(nci,
+        test_restart_done, loop);
+    test_run_loop(&test_opt, loop);
     nci_core_remove_handler(nci, id);
+
+    g_assert(nci->current_state == NCI_RFST_IDLE);
+    g_assert(nci->next_state == NCI_RFST_IDLE);
 
     nci_core_free(nci);
     test_hal_io_free(hal);
@@ -983,6 +1129,7 @@ struct test_nci_sm_entry {
             guint len;
             guint8 cid;
         } send_data;
+        GUtilData expect_cmd;
         struct test_nci_sm_entry_queue_read {
             const void* data;
             guint len;
@@ -1019,6 +1166,9 @@ struct test_nci_sm_entry {
 #define TEST_NCI_SM_QUEUE_NTF(bytes) { \
     .func = test_nci_sm_queue_read, \
     .data.queue_read = { .data = bytes, .len = sizeof(bytes), .ntf = TRUE } }
+#define TEST_NCI_SM_EXPECT_CMD(write_data) { \
+    .func = test_nci_sm_expect_cmd, \
+    .data.expect_cmd = { .bytes = write_data, .size = sizeof(write_data) } }
 #define TEST_NCI_SM_ASSERT_STATES(current,next) { \
     .func = test_nci_sm_assert_states, \
     .data.assert_states = { .current_state = current, .next_state = next } }
@@ -1031,6 +1181,8 @@ struct test_nci_sm_entry {
 #define TEST_NCI_SM_SET_OP_MODE(mode) { \
     .func = test_nci_sm_set_op_mode, \
     .data.op_mode = { .op_mode = mode } }
+#define TEST_NCI_SM_SYNC() { \
+    .func = test_nci_sm_sync }
 #define TEST_NCI_SM_WAIT_STATE(wait_state) { \
     .func = test_nci_sm_wait_state, \
     .data.state = { .state = wait_state } }
@@ -1097,6 +1249,17 @@ test_nci_sm_queue_read(
 
 static
 void
+test_nci_sm_expect_cmd(
+    TestNciSm* test)
+{
+    const GUtilData* expected = &test->entry->data.expect_cmd;
+
+    g_ptr_array_add(test->hal->cmd_expected,
+        g_bytes_new_static(expected->bytes, expected->size));
+}
+
+static
+void
 test_nci_sm_assert_states(
     TestNciSm* test)
 {
@@ -1114,6 +1277,24 @@ test_nci_sm_set_state(
     TestNciSm* test)
 {
     nci_core_set_state(test->nci, test->entry->data.state.state);
+}
+
+static
+void
+test_nci_sm_sync(
+    TestNciSm* test)
+{
+    TestHalIo* hal = test->hal;
+
+    while (hal->write_id || hal->cmd_expected->len > 0) {
+        if (hal->write_id) {
+            GDEBUG("Waiting for pending write to complete");
+        } else {
+            GDEBUG("Waiting for expected command to be submitted");
+        }
+        hal->write_flush_loop = test->loop;
+        g_main_loop_run(test->loop);
+    }
 }
 
 static
@@ -1205,9 +1386,13 @@ test_nci_sm(
     test.data = user_data;
     test.entry = test.data->entries;
 
-    test.nci->cmd_timeout = (test_opt.flags & TEST_FLAG_DEBUG) ? 0 :
-        TEST_DEFAULT_CMD_TIMEOUT;
-    timeout_id = test_setup_timeout(&test_opt);
+    if (test_opt.flags & TEST_FLAG_DEBUG) {
+        test.nci->cmd_timeout = 0;
+        timeout_id = 0;
+    } else {
+        test.nci->cmd_timeout = TEST_DEFAULT_CMD_TIMEOUT;
+        timeout_id = test_setup_timeout(&test_opt);
+    }
     while (test.entry->func) {
         test.entry->func(&test);
         test.entry++;
@@ -1224,133 +1409,196 @@ test_nci_sm(
 /* State machine tests */
 
 static const TestSmEntry test_nci_sm_init_ok_default_duration[] = {
+    TEST_NCI_SM_EXPECT_CMD(CORE_RESET_CMD),
     TEST_NCI_SM_SET_STATE(NCI_RFST_IDLE),
     TEST_NCI_SM_QUEUE_RSP(CORE_RESET_RSP),
+    TEST_NCI_SM_EXPECT_CMD(CORE_INIT_CMD_V1),
     TEST_NCI_SM_QUEUE_RSP(CORE_INIT_RSP),
+    TEST_NCI_SM_EXPECT_CMD(CORE_GET_CONFIG_CMD),
     TEST_NCI_SM_QUEUE_RSP(CORE_GET_CONFIG_RSP_DEFAULT_DURATION),
     TEST_NCI_SM_WAIT_STATE(NCI_RFST_IDLE),
     TEST_NCI_SM_END()
 };
 
 static const TestSmEntry test_nci_sm_init_ok_no_duration[] = {
+    TEST_NCI_SM_EXPECT_CMD(CORE_RESET_CMD),
     TEST_NCI_SM_SET_STATE(NCI_RFST_IDLE),
     TEST_NCI_SM_QUEUE_RSP(CORE_RESET_RSP),
+    TEST_NCI_SM_EXPECT_CMD(CORE_INIT_CMD_V1),
     TEST_NCI_SM_QUEUE_RSP(CORE_INIT_RSP),
+    TEST_NCI_SM_EXPECT_CMD(CORE_GET_CONFIG_CMD),
     TEST_NCI_SM_QUEUE_RSP(CORE_GET_CONFIG_RSP),
+    TEST_NCI_SM_EXPECT_CMD(CORE_SET_CONFIG_CMD),
     TEST_NCI_SM_QUEUE_RSP(CORE_SET_CONFIG_RSP),
     TEST_NCI_SM_WAIT_STATE(NCI_RFST_IDLE),
     TEST_NCI_SM_END()
 };
 
 static const TestSmEntry test_nci_sm_init_ok_wrong_duration[] = {
+    TEST_NCI_SM_EXPECT_CMD(CORE_RESET_CMD),
     TEST_NCI_SM_SET_STATE(NCI_RFST_IDLE),
     TEST_NCI_SM_QUEUE_RSP(CORE_RESET_RSP),
+    TEST_NCI_SM_EXPECT_CMD(CORE_INIT_CMD_V1),
     TEST_NCI_SM_QUEUE_RSP(CORE_INIT_RSP),
+    TEST_NCI_SM_EXPECT_CMD(CORE_GET_CONFIG_CMD),
     TEST_NCI_SM_QUEUE_RSP(CORE_GET_CONFIG_RSP_WRONG_DURATION),
+    TEST_NCI_SM_EXPECT_CMD(CORE_SET_CONFIG_CMD),
     TEST_NCI_SM_QUEUE_RSP(CORE_SET_CONFIG_RSP),
     TEST_NCI_SM_WAIT_STATE(NCI_RFST_IDLE),
     TEST_NCI_SM_END()
 };
 
 static const TestSmEntry test_nci_sm_init_ok_broken_duration1[] = {
+    TEST_NCI_SM_EXPECT_CMD(CORE_RESET_CMD),
     TEST_NCI_SM_SET_STATE(NCI_RFST_IDLE),
     TEST_NCI_SM_QUEUE_RSP(CORE_RESET_RSP),
+    TEST_NCI_SM_EXPECT_CMD(CORE_INIT_CMD_V1),
     TEST_NCI_SM_QUEUE_RSP(CORE_INIT_RSP),
+    TEST_NCI_SM_EXPECT_CMD(CORE_GET_CONFIG_CMD),
     TEST_NCI_SM_QUEUE_RSP(CORE_GET_CONFIG_RSP_BROKEN_DURATION_1),
+    TEST_NCI_SM_EXPECT_CMD(CORE_SET_CONFIG_CMD),
     TEST_NCI_SM_QUEUE_RSP(CORE_SET_CONFIG_RSP),
     TEST_NCI_SM_WAIT_STATE(NCI_RFST_IDLE),
     TEST_NCI_SM_END()
 };
 
 static const TestSmEntry test_nci_sm_init_ok_broken_duration2[] = {
+    TEST_NCI_SM_EXPECT_CMD(CORE_RESET_CMD),
     TEST_NCI_SM_SET_STATE(NCI_RFST_IDLE),
     TEST_NCI_SM_QUEUE_RSP(CORE_RESET_RSP),
+    TEST_NCI_SM_EXPECT_CMD(CORE_INIT_CMD_V1),
     TEST_NCI_SM_QUEUE_RSP(CORE_INIT_RSP),
+    TEST_NCI_SM_EXPECT_CMD(CORE_GET_CONFIG_CMD),
     TEST_NCI_SM_QUEUE_RSP(CORE_GET_CONFIG_RSP_BROKEN_DURATION_2),
+    TEST_NCI_SM_EXPECT_CMD(CORE_SET_CONFIG_CMD),
     TEST_NCI_SM_QUEUE_RSP(CORE_SET_CONFIG_RSP),
     TEST_NCI_SM_WAIT_STATE(NCI_RFST_IDLE),
     TEST_NCI_SM_END()
 };
 
 static const TestSmEntry test_nci_sm_init_ok_broken_duration3[] = {
+    TEST_NCI_SM_EXPECT_CMD(CORE_RESET_CMD),
     TEST_NCI_SM_SET_STATE(NCI_RFST_IDLE),
     TEST_NCI_SM_QUEUE_RSP(CORE_RESET_RSP),
+    TEST_NCI_SM_EXPECT_CMD(CORE_INIT_CMD_V1),
     TEST_NCI_SM_QUEUE_RSP(CORE_INIT_RSP),
+    TEST_NCI_SM_EXPECT_CMD(CORE_GET_CONFIG_CMD),
     TEST_NCI_SM_QUEUE_RSP(CORE_GET_CONFIG_RSP_BROKEN_DURATION_3),
+    TEST_NCI_SM_EXPECT_CMD(CORE_SET_CONFIG_CMD),
     TEST_NCI_SM_QUEUE_RSP(CORE_SET_CONFIG_RSP),
     TEST_NCI_SM_WAIT_STATE(NCI_RFST_IDLE),
     TEST_NCI_SM_END()
 };
 
 static const TestSmEntry test_nci_sm_init_timeout[] = {
-    TEST_NCI_SM_SET_TIMEOUT(500),
+    TEST_NCI_SM_SET_TIMEOUT(TEST_SHORT_TIMEOUT),
+    TEST_NCI_SM_EXPECT_CMD(CORE_RESET_CMD),
     TEST_NCI_SM_SET_STATE(NCI_RFST_IDLE),
     TEST_NCI_SM_QUEUE_RSP(CORE_RESET_RSP),
+    TEST_NCI_SM_EXPECT_CMD(CORE_INIT_CMD_V1),
     /* No CORE_INIT_RSP */
     TEST_NCI_SM_WAIT_STATE(NCI_STATE_ERROR),
     TEST_NCI_SM_END()
 };
 
+static const TestSmEntry test_nci_sm_reset_timeout[] = {
+    TEST_NCI_SM_SET_TIMEOUT(TEST_SHORT_TIMEOUT),
+    TEST_NCI_SM_EXPECT_CMD(CORE_RESET_CMD),
+    TEST_NCI_SM_SET_STATE(NCI_RFST_IDLE),
+    /* No CORE_RESET_RSP */
+    TEST_NCI_SM_WAIT_STATE(NCI_STATE_ERROR),
+    TEST_NCI_SM_END()
+};
+
 static const TestSmEntry test_nci_sm_get_config_timeout[] = {
-    TEST_NCI_SM_SET_TIMEOUT(500),
+    TEST_NCI_SM_SET_TIMEOUT(TEST_SHORT_TIMEOUT),
+    TEST_NCI_SM_EXPECT_CMD(CORE_RESET_CMD),
     TEST_NCI_SM_SET_STATE(NCI_RFST_IDLE),
     TEST_NCI_SM_QUEUE_RSP(CORE_RESET_RSP),
+    TEST_NCI_SM_EXPECT_CMD(CORE_INIT_CMD_V1),
     TEST_NCI_SM_QUEUE_RSP(CORE_INIT_RSP),
+    TEST_NCI_SM_EXPECT_CMD(CORE_GET_CONFIG_CMD),
     /* No CORE_GET_CONFIG_RSP */
     TEST_NCI_SM_WAIT_STATE(NCI_STATE_ERROR),
     TEST_NCI_SM_END()
 };
 
 static const TestSmEntry test_nci_sm_set_config_timeout[] = {
-    TEST_NCI_SM_SET_TIMEOUT(500),
+    TEST_NCI_SM_SET_TIMEOUT(TEST_SHORT_TIMEOUT),
+    TEST_NCI_SM_EXPECT_CMD(CORE_RESET_CMD),
     TEST_NCI_SM_SET_STATE(NCI_RFST_IDLE),
     TEST_NCI_SM_QUEUE_RSP(CORE_RESET_RSP),
+    TEST_NCI_SM_EXPECT_CMD(CORE_INIT_CMD_V1),
     TEST_NCI_SM_QUEUE_RSP(CORE_INIT_RSP),
+    TEST_NCI_SM_EXPECT_CMD(CORE_GET_CONFIG_CMD),
     TEST_NCI_SM_QUEUE_RSP(CORE_GET_CONFIG_RSP),
+    TEST_NCI_SM_EXPECT_CMD(CORE_SET_CONFIG_CMD),
     /* No CORE_SET_CONFIG_RSP */
     TEST_NCI_SM_WAIT_STATE(NCI_STATE_ERROR),
     TEST_NCI_SM_END()
 };
 
 static const TestSmEntry test_nci_sm_init_v2[] = {
+    TEST_NCI_SM_EXPECT_CMD(CORE_RESET_CMD),
     TEST_NCI_SM_SET_STATE(NCI_RFST_IDLE),
     TEST_NCI_SM_QUEUE_RSP(CORE_RESET_V2_RSP),
     TEST_NCI_SM_QUEUE_NTF(CORE_RESET_V2_NTF),
+    TEST_NCI_SM_EXPECT_CMD(CORE_INIT_CMD_V2),
     TEST_NCI_SM_QUEUE_RSP(CORE_INIT_V2_RSP),
+    TEST_NCI_SM_EXPECT_CMD(CORE_GET_CONFIG_CMD),
     TEST_NCI_SM_QUEUE_RSP(CORE_GET_CONFIG_RSP),
+    TEST_NCI_SM_EXPECT_CMD(CORE_SET_CONFIG_CMD),
     TEST_NCI_SM_QUEUE_RSP(CORE_SET_CONFIG_RSP),
     TEST_NCI_SM_WAIT_STATE(NCI_RFST_IDLE),
     TEST_NCI_SM_END()
 };
 
 static const TestSmEntry test_nci_sm_init_v2_error[] = {
+    TEST_NCI_SM_EXPECT_CMD(CORE_RESET_CMD),
     TEST_NCI_SM_SET_STATE(NCI_RFST_IDLE),
     TEST_NCI_SM_QUEUE_RSP(CORE_RESET_V2_RSP),
     TEST_NCI_SM_QUEUE_NTF(CORE_RESET_V2_NTF),
+    TEST_NCI_SM_EXPECT_CMD(CORE_INIT_CMD_V2),
     TEST_NCI_SM_QUEUE_RSP(CORE_INIT_V2_RSP_ERROR),
     TEST_NCI_SM_WAIT_STATE(NCI_STATE_ERROR),
     TEST_NCI_SM_END()
 };
 
 static const TestSmEntry test_nci_sm_init_v2_broken1[] = {
+    TEST_NCI_SM_EXPECT_CMD(CORE_RESET_CMD),
     TEST_NCI_SM_SET_STATE(NCI_RFST_IDLE),
     TEST_NCI_SM_QUEUE_RSP(CORE_RESET_V2_RSP),
     TEST_NCI_SM_QUEUE_NTF(CORE_RESET_V2_NTF),
+    TEST_NCI_SM_EXPECT_CMD(CORE_INIT_CMD_V2),
     TEST_NCI_SM_QUEUE_RSP(CORE_INIT_V2_RSP_BROKEN1),
     TEST_NCI_SM_WAIT_STATE(NCI_STATE_ERROR),
     TEST_NCI_SM_END()
 };
 
 static const TestSmEntry test_nci_sm_init_v2_broken2[] = {
+    TEST_NCI_SM_EXPECT_CMD(CORE_RESET_CMD),
     TEST_NCI_SM_SET_STATE(NCI_RFST_IDLE),
     TEST_NCI_SM_QUEUE_RSP(CORE_RESET_V2_RSP),
     TEST_NCI_SM_QUEUE_NTF(CORE_RESET_V2_NTF),
+    TEST_NCI_SM_EXPECT_CMD(CORE_INIT_CMD_V2),
     TEST_NCI_SM_QUEUE_RSP(CORE_INIT_V2_RSP_BROKEN2),
     TEST_NCI_SM_WAIT_STATE(NCI_STATE_ERROR),
     TEST_NCI_SM_END()
 };
 
+static const TestSmEntry test_nci_sm_init_v2_timeout[] = {
+    TEST_NCI_SM_SET_TIMEOUT(TEST_SHORT_TIMEOUT),
+    TEST_NCI_SM_EXPECT_CMD(CORE_RESET_CMD),
+    TEST_NCI_SM_SET_STATE(NCI_RFST_IDLE),
+    TEST_NCI_SM_QUEUE_RSP(CORE_RESET_V2_RSP),
+    TEST_NCI_SM_QUEUE_NTF(CORE_RESET_V2_NTF),
+    TEST_NCI_SM_EXPECT_CMD(CORE_INIT_CMD_V2),
+    TEST_NCI_SM_WAIT_STATE(NCI_STATE_ERROR),
+    TEST_NCI_SM_END()
+};
+
 static const TestSmEntry test_nci_sm_reset_failed[] = {
+    TEST_NCI_SM_EXPECT_CMD(CORE_RESET_CMD),
     TEST_NCI_SM_SET_STATE(NCI_RFST_IDLE),
     TEST_NCI_SM_QUEUE_RSP(CORE_RESET_RSP_ERROR),
     TEST_NCI_SM_QUEUE_NTF(CORE_RESET_RSP), /* Ignored */
@@ -1359,6 +1607,7 @@ static const TestSmEntry test_nci_sm_reset_failed[] = {
 };
 
 static const TestSmEntry test_nci_sm_reset_broken[] = {
+    TEST_NCI_SM_EXPECT_CMD(CORE_RESET_CMD),
     TEST_NCI_SM_SET_STATE(NCI_RFST_IDLE),
     TEST_NCI_SM_QUEUE_RSP(CORE_RESET_RSP_BROKEN),
     TEST_NCI_SM_WAIT_STATE(NCI_STATE_ERROR),
@@ -1366,50 +1615,66 @@ static const TestSmEntry test_nci_sm_reset_broken[] = {
 };
 
 static const TestSmEntry test_nci_sm_init_broken[] = {
+    TEST_NCI_SM_EXPECT_CMD(CORE_RESET_CMD),
     TEST_NCI_SM_SET_STATE(NCI_RFST_IDLE),
     TEST_NCI_SM_QUEUE_RSP(CORE_RESET_RSP),
     TEST_NCI_SM_QUEUE_NTF(CORE_RESET_V2_NTF), /* Unexpected (ignored) */
+    TEST_NCI_SM_EXPECT_CMD(CORE_INIT_CMD_V1),
     TEST_NCI_SM_QUEUE_RSP(CORE_INIT_RSP_BROKEN),
     TEST_NCI_SM_WAIT_STATE(NCI_STATE_ERROR),
     TEST_NCI_SM_END()
 };
 
 static const TestSmEntry test_nci_sm_get_config_error[] = {
+    TEST_NCI_SM_EXPECT_CMD(CORE_RESET_CMD),
     TEST_NCI_SM_SET_STATE(NCI_RFST_IDLE),
     TEST_NCI_SM_QUEUE_RSP(CORE_RESET_RSP),
+    TEST_NCI_SM_EXPECT_CMD(CORE_INIT_CMD_V1),
     TEST_NCI_SM_QUEUE_RSP(CORE_INIT_RSP),
     /* GET_CONFIG errors are ignored */
+    TEST_NCI_SM_EXPECT_CMD(CORE_GET_CONFIG_CMD),
     TEST_NCI_SM_QUEUE_RSP(CORE_GET_CONFIG_RSP_INVALID_PARAM),
+    TEST_NCI_SM_EXPECT_CMD(CORE_SET_CONFIG_CMD),
     TEST_NCI_SM_QUEUE_RSP(CORE_SET_CONFIG_RSP),
     TEST_NCI_SM_WAIT_STATE(NCI_RFST_IDLE),
     TEST_NCI_SM_END()
 };
 
 static const TestSmEntry test_nci_sm_get_config_broken[] = {
+    TEST_NCI_SM_EXPECT_CMD(CORE_RESET_CMD),
     TEST_NCI_SM_SET_STATE(NCI_RFST_IDLE),
     TEST_NCI_SM_QUEUE_RSP(CORE_RESET_RSP),
+    TEST_NCI_SM_EXPECT_CMD(CORE_INIT_CMD_V1),
     TEST_NCI_SM_QUEUE_RSP(CORE_INIT_RSP),
+    TEST_NCI_SM_EXPECT_CMD(CORE_GET_CONFIG_CMD),
     TEST_NCI_SM_QUEUE_RSP(CORE_GET_CONFIG_BROKEN),
-    TEST_NCI_SM_WAIT_STATE(NCI_STATE_ERROR),
-    TEST_NCI_SM_END()
-};
-
-static const TestSmEntry test_nci_sm_ignore_unexpected_rsp[] = {
-    TEST_NCI_SM_SET_STATE(NCI_RFST_IDLE),
-    TEST_NCI_SM_QUEUE_RSP(CORE_INIT_RSP), /* Unexpected (ignored) */
-    TEST_NCI_SM_QUEUE_NTF(CORE_RESET_RSP),
-    TEST_NCI_SM_QUEUE_RSP(CORE_INIT_RSP),
-    TEST_NCI_SM_QUEUE_RSP(CORE_GET_CONFIG_RSP),
+    TEST_NCI_SM_EXPECT_CMD(CORE_SET_CONFIG_CMD),
     TEST_NCI_SM_QUEUE_RSP(CORE_SET_CONFIG_RSP),
     TEST_NCI_SM_WAIT_STATE(NCI_RFST_IDLE),
     TEST_NCI_SM_END()
 };
 
-static const TestSmEntry test_nci_sm_discovery_failed[] = {
-    TEST_NCI_SM_QUEUE_RSP(CORE_RESET_RSP),
+static const TestSmEntry test_nci_sm_ignore_unexpected_rsp[] = {
+    TEST_NCI_SM_EXPECT_CMD(CORE_RESET_CMD),
+    TEST_NCI_SM_SET_STATE(NCI_RFST_IDLE),
+    TEST_NCI_SM_QUEUE_RSP(CORE_INIT_RSP), /* Unexpected (ignored) */
+    TEST_NCI_SM_QUEUE_NTF(CORE_RESET_RSP),
+    TEST_NCI_SM_EXPECT_CMD(CORE_INIT_CMD_V1),
     TEST_NCI_SM_QUEUE_RSP(CORE_INIT_RSP),
-    TEST_NCI_SM_QUEUE_RSP(CORE_GET_CONFIG_RSP),
-    TEST_NCI_SM_QUEUE_RSP(CORE_SET_CONFIG_RSP),
+    TEST_NCI_SM_EXPECT_CMD(CORE_GET_CONFIG_CMD),
+    /* This GET_CONFIG_RSP contains default TOTAL_DURATION + extra parameter */
+    TEST_NCI_SM_QUEUE_RSP(CORE_GET_CONFIG_RSP_DEFAULT_DURATION_EXTRA),
+    TEST_NCI_SM_WAIT_STATE(NCI_RFST_IDLE),
+    TEST_NCI_SM_END()
+};
+
+static const TestSmEntry test_nci_sm_discovery_failed[] = {
+    TEST_NCI_SM_EXPECT_CMD(CORE_RESET_CMD),
+    TEST_NCI_SM_QUEUE_RSP(CORE_RESET_RSP),
+    TEST_NCI_SM_EXPECT_CMD(CORE_INIT_CMD_V1),
+    TEST_NCI_SM_QUEUE_RSP(CORE_INIT_RSP),
+    TEST_NCI_SM_EXPECT_CMD(CORE_GET_CONFIG_CMD),
+    TEST_NCI_SM_QUEUE_RSP(CORE_GET_CONFIG_RSP_DEFAULT_DURATION),
     TEST_NCI_SM_QUEUE_RSP(RF_SET_LISTEN_MODE_ROUTING_RSP),
     TEST_NCI_SM_QUEUE_RSP(RF_DISCOVER_MAP_RSP),
     TEST_NCI_SM_QUEUE_RSP(RF_DISCOVER_RSP_ERROR),
@@ -1419,12 +1684,17 @@ static const TestSmEntry test_nci_sm_discovery_failed[] = {
 };
 
 static const TestSmEntry test_nci_sm_discovery_broken[] = {
+    TEST_NCI_SM_EXPECT_CMD(CORE_RESET_CMD),
     TEST_NCI_SM_QUEUE_RSP(CORE_RESET_RSP),
+    TEST_NCI_SM_EXPECT_CMD(CORE_INIT_CMD_V1),
     TEST_NCI_SM_QUEUE_RSP(CORE_INIT_RSP),
-    TEST_NCI_SM_QUEUE_RSP(CORE_GET_CONFIG_RSP),
-    TEST_NCI_SM_QUEUE_RSP(CORE_SET_CONFIG_RSP),
+    TEST_NCI_SM_EXPECT_CMD(CORE_GET_CONFIG_CMD),
+    TEST_NCI_SM_QUEUE_RSP(CORE_GET_CONFIG_RSP_DEFAULT_DURATION),
+    TEST_NCI_SM_EXPECT_CMD(RF_SET_LISTEN_MODE_ROUTING_CMD_TECHNOLOGY_A_B_F),
     TEST_NCI_SM_QUEUE_RSP(RF_SET_LISTEN_MODE_ROUTING_RSP),
+    TEST_NCI_SM_EXPECT_CMD(RF_DISCOVER_MAP_CMD_A_B_F),
     TEST_NCI_SM_QUEUE_RSP(RF_DISCOVER_MAP_RSP),
+    TEST_NCI_SM_EXPECT_CMD(RF_DISCOVER_CMD_A_B_F),
     TEST_NCI_SM_QUEUE_RSP(RF_DISCOVER_RSP_BROKEN),
     TEST_NCI_SM_SET_STATE(NCI_RFST_DISCOVERY),
     TEST_NCI_SM_WAIT_STATE(NCI_STATE_ERROR),
@@ -1432,169 +1702,218 @@ static const TestSmEntry test_nci_sm_discovery_broken[] = {
 };
 
 static const TestSmEntry test_nci_sm_discovery_v2[] = {
+    TEST_NCI_SM_EXPECT_CMD(CORE_RESET_CMD),
     TEST_NCI_SM_SET_STATE(NCI_RFST_DISCOVERY),
     TEST_NCI_SM_ASSERT_STATES(NCI_STATE_INIT, NCI_RFST_DISCOVERY),
     TEST_NCI_SM_QUEUE_RSP(CORE_RESET_V2_RSP),
     TEST_NCI_SM_QUEUE_NTF(CORE_RESET_V2_NTF),
+    TEST_NCI_SM_EXPECT_CMD(CORE_INIT_CMD_V2),
     TEST_NCI_SM_QUEUE_RSP(CORE_INIT_V2_RSP_NO_ROUTING),
-    TEST_NCI_SM_QUEUE_RSP(CORE_GET_CONFIG_RSP),
-    TEST_NCI_SM_QUEUE_RSP(CORE_SET_CONFIG_RSP),
+    TEST_NCI_SM_EXPECT_CMD(CORE_GET_CONFIG_CMD),
+    TEST_NCI_SM_QUEUE_RSP(CORE_GET_CONFIG_RSP_DEFAULT_DURATION),
     TEST_NCI_SM_WAIT_STATE(NCI_RFST_IDLE),
 
     TEST_NCI_SM_ASSERT_STATES(NCI_RFST_IDLE, NCI_RFST_DISCOVERY),
+    TEST_NCI_SM_EXPECT_CMD(RF_DISCOVER_MAP_CMD_A_B_F),
     TEST_NCI_SM_QUEUE_RSP(RF_DISCOVER_MAP_RSP),
+    TEST_NCI_SM_EXPECT_CMD(RF_DISCOVER_CMD_A_B_F),
     TEST_NCI_SM_QUEUE_RSP(RF_DISCOVER_RSP),
     TEST_NCI_SM_WAIT_STATE(NCI_RFST_DISCOVERY),
     TEST_NCI_SM_END()
 };
 
 static const TestSmEntry test_nci_sm_discovery_v2_protocol[] = {
+    TEST_NCI_SM_EXPECT_CMD(CORE_RESET_CMD),
     TEST_NCI_SM_SET_STATE(NCI_RFST_DISCOVERY),
     TEST_NCI_SM_ASSERT_STATES(NCI_STATE_INIT, NCI_RFST_DISCOVERY),
     TEST_NCI_SM_QUEUE_RSP(CORE_RESET_V2_RSP),
     TEST_NCI_SM_QUEUE_NTF(CORE_RESET_V2_NTF),
+    TEST_NCI_SM_EXPECT_CMD(CORE_INIT_CMD_V2),
     TEST_NCI_SM_QUEUE_RSP(CORE_INIT_V2_RSP),
-    TEST_NCI_SM_QUEUE_RSP(CORE_GET_CONFIG_RSP),
-    TEST_NCI_SM_QUEUE_RSP(CORE_SET_CONFIG_RSP),
+    TEST_NCI_SM_EXPECT_CMD(CORE_GET_CONFIG_CMD),
+    TEST_NCI_SM_QUEUE_RSP(CORE_GET_CONFIG_RSP_DEFAULT_DURATION),
     TEST_NCI_SM_WAIT_STATE(NCI_RFST_IDLE),
 
     TEST_NCI_SM_ASSERT_STATES(NCI_RFST_IDLE, NCI_RFST_DISCOVERY),
+    TEST_NCI_SM_EXPECT_CMD(RF_SET_LISTEN_MODE_ROUTING_CMD_TECHNOLOGY_A_B_F),
     TEST_NCI_SM_QUEUE_RSP(RF_SET_LISTEN_MODE_ROUTING_RSP),
+    TEST_NCI_SM_EXPECT_CMD(RF_DISCOVER_MAP_CMD_A_B_F),
     TEST_NCI_SM_QUEUE_RSP(RF_DISCOVER_MAP_RSP),
+    TEST_NCI_SM_EXPECT_CMD(RF_DISCOVER_CMD_A_B_F),
     TEST_NCI_SM_QUEUE_RSP(RF_DISCOVER_RSP),
     TEST_NCI_SM_WAIT_STATE(NCI_RFST_DISCOVERY),
     TEST_NCI_SM_END()
 };
 
 static const TestSmEntry test_nci_sm_discovery_v2_protocol_error[] = {
+    TEST_NCI_SM_EXPECT_CMD(CORE_RESET_CMD),
     TEST_NCI_SM_SET_STATE(NCI_RFST_DISCOVERY),
     TEST_NCI_SM_ASSERT_STATES(NCI_STATE_INIT, NCI_RFST_DISCOVERY),
     TEST_NCI_SM_QUEUE_RSP(CORE_RESET_V2_RSP),
     TEST_NCI_SM_QUEUE_NTF(CORE_RESET_V2_NTF),
+    TEST_NCI_SM_EXPECT_CMD(CORE_INIT_CMD_V2),
     TEST_NCI_SM_QUEUE_RSP(CORE_INIT_V2_RSP_NO_TECHNOLOGY_ROUTING),
-    TEST_NCI_SM_QUEUE_RSP(CORE_GET_CONFIG_RSP),
-    TEST_NCI_SM_QUEUE_RSP(CORE_SET_CONFIG_RSP),
+    TEST_NCI_SM_EXPECT_CMD(CORE_GET_CONFIG_CMD),
+    TEST_NCI_SM_QUEUE_RSP(CORE_GET_CONFIG_RSP_DEFAULT_DURATION),
     TEST_NCI_SM_WAIT_STATE(NCI_RFST_IDLE),
 
     TEST_NCI_SM_ASSERT_STATES(NCI_RFST_IDLE, NCI_RFST_DISCOVERY),
+    TEST_NCI_SM_EXPECT_CMD(RF_SET_LISTEN_MODE_ROUTING_CMD_PROTOCOL_A_B_F),
     TEST_NCI_SM_QUEUE_RSP(RF_SET_LISTEN_MODE_ROUTING_RSP_ERROR),
+    TEST_NCI_SM_EXPECT_CMD(RF_DISCOVER_MAP_CMD_A_B_F),
     TEST_NCI_SM_QUEUE_RSP(RF_DISCOVER_MAP_RSP),
+    TEST_NCI_SM_EXPECT_CMD(RF_DISCOVER_CMD_A_B_F),
     TEST_NCI_SM_QUEUE_RSP(RF_DISCOVER_RSP),
     TEST_NCI_SM_WAIT_STATE(NCI_RFST_DISCOVERY),
     TEST_NCI_SM_END()
 };
 
 static const TestSmEntry test_nci_sm_discovery_v2_technology1[] = {
+    TEST_NCI_SM_EXPECT_CMD(CORE_RESET_CMD),
     TEST_NCI_SM_SET_STATE(NCI_RFST_DISCOVERY),
     TEST_NCI_SM_ASSERT_STATES(NCI_STATE_INIT, NCI_RFST_DISCOVERY),
     TEST_NCI_SM_QUEUE_RSP(CORE_RESET_V2_RSP),
     TEST_NCI_SM_QUEUE_NTF(CORE_RESET_V2_NTF),
+    TEST_NCI_SM_EXPECT_CMD(CORE_INIT_CMD_V2),
     TEST_NCI_SM_QUEUE_RSP(CORE_INIT_V2_RSP),
-    TEST_NCI_SM_QUEUE_RSP(CORE_GET_CONFIG_RSP),
-    TEST_NCI_SM_QUEUE_RSP(CORE_SET_CONFIG_RSP),
+    TEST_NCI_SM_EXPECT_CMD(CORE_GET_CONFIG_CMD),
+    TEST_NCI_SM_QUEUE_RSP(CORE_GET_CONFIG_RSP_DEFAULT_DURATION),
     TEST_NCI_SM_WAIT_STATE(NCI_RFST_IDLE),
 
     TEST_NCI_SM_ASSERT_STATES(NCI_RFST_IDLE, NCI_RFST_DISCOVERY),
+    TEST_NCI_SM_EXPECT_CMD(RF_SET_LISTEN_MODE_ROUTING_CMD_TECHNOLOGY_A_B_F),
     TEST_NCI_SM_QUEUE_RSP(RF_SET_LISTEN_MODE_ROUTING_RSP_ERROR),
+    TEST_NCI_SM_EXPECT_CMD(RF_SET_LISTEN_MODE_ROUTING_CMD_PROTOCOL_A_B_F),
     TEST_NCI_SM_QUEUE_RSP(RF_SET_LISTEN_MODE_ROUTING_RSP),
+    TEST_NCI_SM_EXPECT_CMD(RF_DISCOVER_MAP_CMD_A_B_F),
     TEST_NCI_SM_QUEUE_RSP(RF_DISCOVER_MAP_RSP),
+    TEST_NCI_SM_EXPECT_CMD(RF_DISCOVER_CMD_A_B_F),
     TEST_NCI_SM_QUEUE_RSP(RF_DISCOVER_RSP),
     TEST_NCI_SM_WAIT_STATE(NCI_RFST_DISCOVERY),
     TEST_NCI_SM_END()
 };
 
 static const TestSmEntry test_nci_sm_discovery_v2_technology2[] = {
+    TEST_NCI_SM_EXPECT_CMD(CORE_RESET_CMD),
     TEST_NCI_SM_SET_STATE(NCI_RFST_DISCOVERY),
     TEST_NCI_SM_ASSERT_STATES(NCI_STATE_INIT, NCI_RFST_DISCOVERY),
     TEST_NCI_SM_QUEUE_RSP(CORE_RESET_V2_RSP),
     TEST_NCI_SM_QUEUE_NTF(CORE_RESET_V2_NTF),
+    TEST_NCI_SM_EXPECT_CMD(CORE_INIT_CMD_V2),
     TEST_NCI_SM_QUEUE_RSP(CORE_INIT_V2_RSP),
-    TEST_NCI_SM_QUEUE_RSP(CORE_GET_CONFIG_RSP),
-    TEST_NCI_SM_QUEUE_RSP(CORE_SET_CONFIG_RSP),
+    TEST_NCI_SM_EXPECT_CMD(CORE_GET_CONFIG_CMD),
+    TEST_NCI_SM_QUEUE_RSP(CORE_GET_CONFIG_RSP_DEFAULT_DURATION),
     TEST_NCI_SM_WAIT_STATE(NCI_RFST_IDLE),
 
     TEST_NCI_SM_ASSERT_STATES(NCI_RFST_IDLE, NCI_RFST_DISCOVERY),
+    TEST_NCI_SM_EXPECT_CMD(RF_SET_LISTEN_MODE_ROUTING_CMD_TECHNOLOGY_A_B_F),
     TEST_NCI_SM_QUEUE_RSP(RF_SET_LISTEN_MODE_ROUTING_RSP_BROKEN),
+    TEST_NCI_SM_EXPECT_CMD(RF_SET_LISTEN_MODE_ROUTING_CMD_PROTOCOL_A_B_F),
     TEST_NCI_SM_QUEUE_RSP(RF_SET_LISTEN_MODE_ROUTING_RSP),
+    TEST_NCI_SM_EXPECT_CMD(RF_DISCOVER_MAP_CMD_A_B_F),
     TEST_NCI_SM_QUEUE_RSP(RF_DISCOVER_MAP_RSP),
+    TEST_NCI_SM_EXPECT_CMD(RF_DISCOVER_CMD_A_B_F),
     TEST_NCI_SM_QUEUE_RSP(RF_DISCOVER_RSP),
     TEST_NCI_SM_WAIT_STATE(NCI_RFST_DISCOVERY),
     TEST_NCI_SM_END()
 };
 
 static const TestSmEntry test_nci_sm_discovery_v2_technology3[] = {
+    TEST_NCI_SM_EXPECT_CMD(CORE_RESET_CMD),
     TEST_NCI_SM_SET_STATE(NCI_RFST_DISCOVERY),
     TEST_NCI_SM_ASSERT_STATES(NCI_STATE_INIT, NCI_RFST_DISCOVERY),
     TEST_NCI_SM_QUEUE_RSP(CORE_RESET_V2_RSP),
     TEST_NCI_SM_QUEUE_NTF(CORE_RESET_V2_NTF),
+    TEST_NCI_SM_EXPECT_CMD(CORE_INIT_CMD_V2),
     TEST_NCI_SM_QUEUE_RSP(CORE_INIT_V2_RSP_NO_PROTOCOL_ROUTING),
-    TEST_NCI_SM_QUEUE_RSP(CORE_GET_CONFIG_RSP),
-    TEST_NCI_SM_QUEUE_RSP(CORE_SET_CONFIG_RSP),
+    TEST_NCI_SM_EXPECT_CMD(CORE_GET_CONFIG_CMD),
+    TEST_NCI_SM_QUEUE_RSP(CORE_GET_CONFIG_RSP_DEFAULT_DURATION),
     TEST_NCI_SM_WAIT_STATE(NCI_RFST_IDLE),
 
     TEST_NCI_SM_ASSERT_STATES(NCI_RFST_IDLE, NCI_RFST_DISCOVERY),
+    TEST_NCI_SM_EXPECT_CMD(RF_SET_LISTEN_MODE_ROUTING_CMD_TECHNOLOGY_A_B_F),
     TEST_NCI_SM_QUEUE_RSP(RF_SET_LISTEN_MODE_ROUTING_RSP),
+    TEST_NCI_SM_EXPECT_CMD(RF_DISCOVER_MAP_CMD_A_B_F),
     TEST_NCI_SM_QUEUE_RSP(RF_DISCOVER_MAP_RSP),
+    TEST_NCI_SM_EXPECT_CMD(RF_DISCOVER_CMD_A_B_F),
     TEST_NCI_SM_QUEUE_RSP(RF_DISCOVER_RSP),
     TEST_NCI_SM_WAIT_STATE(NCI_RFST_DISCOVERY),
     TEST_NCI_SM_END()
 };
 
 static const TestSmEntry test_nci_sm_discovery_v2_technology4[] = {
+    TEST_NCI_SM_EXPECT_CMD(CORE_RESET_CMD),
     TEST_NCI_SM_SET_STATE(NCI_RFST_DISCOVERY),
     TEST_NCI_SM_ASSERT_STATES(NCI_STATE_INIT, NCI_RFST_DISCOVERY),
     TEST_NCI_SM_QUEUE_RSP(CORE_RESET_V2_RSP),
     TEST_NCI_SM_QUEUE_NTF(CORE_RESET_V2_NTF),
+    TEST_NCI_SM_EXPECT_CMD(CORE_INIT_CMD_V2),
     TEST_NCI_SM_QUEUE_RSP(CORE_INIT_V2_RSP_NO_PROTOCOL_ROUTING),
-    TEST_NCI_SM_QUEUE_RSP(CORE_GET_CONFIG_RSP),
-    TEST_NCI_SM_QUEUE_RSP(CORE_SET_CONFIG_RSP),
+    TEST_NCI_SM_EXPECT_CMD(CORE_GET_CONFIG_CMD),
+    TEST_NCI_SM_QUEUE_RSP(CORE_GET_CONFIG_RSP_DEFAULT_DURATION),
     TEST_NCI_SM_WAIT_STATE(NCI_RFST_IDLE),
 
     TEST_NCI_SM_ASSERT_STATES(NCI_RFST_IDLE, NCI_RFST_DISCOVERY),
+    TEST_NCI_SM_EXPECT_CMD(RF_SET_LISTEN_MODE_ROUTING_CMD_TECHNOLOGY_A_B_F),
     TEST_NCI_SM_QUEUE_RSP(RF_SET_LISTEN_MODE_ROUTING_RSP_BROKEN),
+    TEST_NCI_SM_EXPECT_CMD(RF_DISCOVER_MAP_CMD_A_B_F),
     TEST_NCI_SM_QUEUE_RSP(RF_DISCOVER_MAP_RSP),
+    TEST_NCI_SM_EXPECT_CMD(RF_DISCOVER_CMD_A_B_F),
     TEST_NCI_SM_QUEUE_RSP(RF_DISCOVER_RSP),
     TEST_NCI_SM_WAIT_STATE(NCI_RFST_DISCOVERY),
     TEST_NCI_SM_END()
 };
 
 static const TestSmEntry test_nci_sm_discovery_v2_technology5[] = {
+    TEST_NCI_SM_EXPECT_CMD(CORE_RESET_CMD),
     TEST_NCI_SM_SET_STATE(NCI_RFST_DISCOVERY),
     TEST_NCI_SM_ASSERT_STATES(NCI_STATE_INIT, NCI_RFST_DISCOVERY),
     TEST_NCI_SM_QUEUE_RSP(CORE_RESET_V2_RSP),
     TEST_NCI_SM_QUEUE_NTF(CORE_RESET_V2_NTF),
+    TEST_NCI_SM_EXPECT_CMD(CORE_INIT_CMD_V2),
     TEST_NCI_SM_QUEUE_RSP(CORE_INIT_V2_RSP_NO_PROTOCOL_ROUTING),
-    TEST_NCI_SM_QUEUE_RSP(CORE_GET_CONFIG_RSP),
-    TEST_NCI_SM_QUEUE_RSP(CORE_SET_CONFIG_RSP),
+    TEST_NCI_SM_EXPECT_CMD(CORE_GET_CONFIG_CMD),
+    TEST_NCI_SM_QUEUE_RSP(CORE_GET_CONFIG_RSP_DEFAULT_DURATION),
     TEST_NCI_SM_WAIT_STATE(NCI_RFST_IDLE),
 
     TEST_NCI_SM_ASSERT_STATES(NCI_RFST_IDLE, NCI_RFST_DISCOVERY),
+    TEST_NCI_SM_EXPECT_CMD(RF_SET_LISTEN_MODE_ROUTING_CMD_TECHNOLOGY_A_B_F),
     TEST_NCI_SM_QUEUE_RSP(RF_SET_LISTEN_MODE_ROUTING_RSP_ERROR),
+    TEST_NCI_SM_EXPECT_CMD(RF_DISCOVER_MAP_CMD_A_B_F),
     TEST_NCI_SM_QUEUE_RSP(RF_DISCOVER_MAP_RSP),
+    TEST_NCI_SM_EXPECT_CMD(RF_DISCOVER_CMD_A_B_F),
     TEST_NCI_SM_QUEUE_RSP(RF_DISCOVER_RSP),
     TEST_NCI_SM_WAIT_STATE(NCI_RFST_DISCOVERY),
     TEST_NCI_SM_END()
 };
 
 static const TestSmEntry test_nci_sm_discover_map_error[] = {
+    TEST_NCI_SM_EXPECT_CMD(CORE_RESET_CMD),
     TEST_NCI_SM_SET_STATE(NCI_RFST_DISCOVERY),
     TEST_NCI_SM_QUEUE_RSP(CORE_RESET_RSP),
+    TEST_NCI_SM_EXPECT_CMD(CORE_INIT_CMD_V1),
     TEST_NCI_SM_QUEUE_RSP(CORE_INIT_RSP),
-    TEST_NCI_SM_QUEUE_RSP(CORE_GET_CONFIG_RSP),
-    TEST_NCI_SM_QUEUE_RSP(CORE_SET_CONFIG_RSP),
+    TEST_NCI_SM_EXPECT_CMD(CORE_GET_CONFIG_CMD),
+    TEST_NCI_SM_QUEUE_RSP(CORE_GET_CONFIG_RSP_DEFAULT_DURATION),
+    TEST_NCI_SM_EXPECT_CMD(RF_SET_LISTEN_MODE_ROUTING_CMD_TECHNOLOGY_A_B_F),
     TEST_NCI_SM_QUEUE_RSP(RF_SET_LISTEN_MODE_ROUTING_RSP),
+    TEST_NCI_SM_EXPECT_CMD(RF_DISCOVER_MAP_CMD_A_B_F),
     TEST_NCI_SM_QUEUE_RSP(RF_DISCOVER_MAP_ERROR),
     TEST_NCI_SM_WAIT_STATE(NCI_STATE_ERROR),
     TEST_NCI_SM_END()
 };
 
 static const TestSmEntry test_nci_sm_discover_map_broken[] = {
+    TEST_NCI_SM_EXPECT_CMD(CORE_RESET_CMD),
     TEST_NCI_SM_SET_STATE(NCI_RFST_DISCOVERY),
     TEST_NCI_SM_QUEUE_RSP(CORE_RESET_RSP),
+    TEST_NCI_SM_EXPECT_CMD(CORE_INIT_CMD_V1),
     TEST_NCI_SM_QUEUE_RSP(CORE_INIT_RSP),
-    TEST_NCI_SM_QUEUE_RSP(CORE_GET_CONFIG_RSP),
-    TEST_NCI_SM_QUEUE_RSP(CORE_SET_CONFIG_RSP),
+    TEST_NCI_SM_EXPECT_CMD(CORE_GET_CONFIG_CMD),
+    TEST_NCI_SM_QUEUE_RSP(CORE_GET_CONFIG_RSP_DEFAULT_DURATION),
+    TEST_NCI_SM_EXPECT_CMD(RF_SET_LISTEN_MODE_ROUTING_CMD_TECHNOLOGY_A_B_F),
     TEST_NCI_SM_QUEUE_RSP(RF_SET_LISTEN_MODE_ROUTING_RSP),
+    TEST_NCI_SM_EXPECT_CMD(RF_DISCOVER_MAP_CMD_A_B_F),
     TEST_NCI_SM_QUEUE_RSP(RF_DISCOVER_MAP_BROKEN),
     TEST_NCI_SM_WAIT_STATE(NCI_STATE_ERROR),
     TEST_NCI_SM_END()
@@ -1603,12 +1922,17 @@ static const TestSmEntry test_nci_sm_discover_map_broken[] = {
 static const TestSmEntry test_nci_sm_discovery_idle_discovery[] = {
     TEST_NCI_SM_SET_OP_MODE(NFC_OP_MODE_RW|NFC_OP_MODE_PEER|NFC_OP_MODE_CE|
                             NFC_OP_MODE_POLL|NFC_OP_MODE_LISTEN),
+    TEST_NCI_SM_EXPECT_CMD(CORE_RESET_CMD),
     TEST_NCI_SM_QUEUE_RSP(CORE_RESET_RSP),
+    TEST_NCI_SM_EXPECT_CMD(CORE_INIT_CMD_V1),
     TEST_NCI_SM_QUEUE_RSP(CORE_INIT_RSP),
-    TEST_NCI_SM_QUEUE_RSP(CORE_GET_CONFIG_RSP),
-    TEST_NCI_SM_QUEUE_RSP(CORE_SET_CONFIG_RSP),
+    TEST_NCI_SM_EXPECT_CMD(CORE_GET_CONFIG_CMD),
+    TEST_NCI_SM_QUEUE_RSP(CORE_GET_CONFIG_RSP_DEFAULT_DURATION),
+    TEST_NCI_SM_EXPECT_CMD(RF_SET_LISTEN_MODE_ROUTING_CMD_TECHNOLOGY_A_B_F),
     TEST_NCI_SM_QUEUE_RSP(RF_SET_LISTEN_MODE_ROUTING_RSP),
+    TEST_NCI_SM_EXPECT_CMD(RF_DISCOVER_MAP_CMD_A_B_F_NFCDEP),
     TEST_NCI_SM_QUEUE_RSP(RF_DISCOVER_MAP_RSP),
+    TEST_NCI_SM_EXPECT_CMD(RF_DISCOVER_CMD_A_B_F_NFCDEP),
     TEST_NCI_SM_QUEUE_RSP(RF_DISCOVER_RSP),
     TEST_NCI_SM_QUEUE_NTF(CORE_GENERIC_ERROR_NTF),  /* Ignored */
     TEST_NCI_SM_QUEUE_NTF(CORE_IGNORED_NTF),        /* Ignored */
@@ -1625,6 +1949,7 @@ static const TestSmEntry test_nci_sm_discovery_idle_discovery[] = {
 
     /* And then switch back to IDLE */
     TEST_NCI_SM_SET_STATE(NCI_RFST_IDLE),
+    TEST_NCI_SM_EXPECT_CMD(RF_DEACTIVATE_IDLE_CMD),
     TEST_NCI_SM_ASSERT_STATES(NCI_RFST_DISCOVERY, NCI_RFST_IDLE),
     TEST_NCI_SM_QUEUE_RSP(RF_DEACTIVATE_RSP),
     TEST_NCI_SM_QUEUE_NTF(CORE_IGNORED_NTF),
@@ -1632,8 +1957,11 @@ static const TestSmEntry test_nci_sm_discovery_idle_discovery[] = {
 
     /* And again to DISCOVERY */
     TEST_NCI_SM_SET_STATE(NCI_RFST_DISCOVERY),
+    TEST_NCI_SM_EXPECT_CMD(RF_SET_LISTEN_MODE_ROUTING_CMD_TECHNOLOGY_A_B_F),
     TEST_NCI_SM_QUEUE_RSP(RF_SET_LISTEN_MODE_ROUTING_RSP),
+    TEST_NCI_SM_EXPECT_CMD(RF_DISCOVER_MAP_CMD_A_B_F_NFCDEP),
     TEST_NCI_SM_QUEUE_RSP(RF_DISCOVER_MAP_RSP),
+    TEST_NCI_SM_EXPECT_CMD(RF_DISCOVER_CMD_A_B_F_NFCDEP),
     TEST_NCI_SM_QUEUE_RSP(RF_DISCOVER_RSP),
     TEST_NCI_SM_ASSERT_STATES(NCI_RFST_IDLE, NCI_RFST_DISCOVERY),
     TEST_NCI_SM_WAIT_STATE(NCI_RFST_DISCOVERY),
@@ -1643,13 +1971,19 @@ static const TestSmEntry test_nci_sm_discovery_idle_discovery[] = {
 static const TestSmEntry test_nci_sm_discovery_idle_discovery2[] = {
     TEST_NCI_SM_SET_OP_MODE(NFC_OP_MODE_RW|NFC_OP_MODE_PEER|NFC_OP_MODE_CE|
                             NFC_OP_MODE_POLL|NFC_OP_MODE_LISTEN),
+    TEST_NCI_SM_EXPECT_CMD(CORE_RESET_CMD),
     TEST_NCI_SM_QUEUE_RSP(CORE_RESET_RSP),
+    TEST_NCI_SM_EXPECT_CMD(CORE_INIT_CMD_V1),
     TEST_NCI_SM_QUEUE_RSP(CORE_INIT_RSP),
-    TEST_NCI_SM_QUEUE_RSP(CORE_GET_CONFIG_RSP),
-    TEST_NCI_SM_QUEUE_RSP(CORE_SET_CONFIG_RSP),
+    TEST_NCI_SM_EXPECT_CMD(CORE_GET_CONFIG_CMD),
+    TEST_NCI_SM_QUEUE_RSP(CORE_GET_CONFIG_RSP_DEFAULT_DURATION),
+    TEST_NCI_SM_EXPECT_CMD(RF_SET_LISTEN_MODE_ROUTING_CMD_TECHNOLOGY_A_B_F),
     TEST_NCI_SM_QUEUE_RSP(RF_SET_LISTEN_MODE_ROUTING_RSP_ERROR),
+    TEST_NCI_SM_EXPECT_CMD(RF_SET_LISTEN_MODE_ROUTING_CMD_PROTOCOL_A_B_F),
     TEST_NCI_SM_QUEUE_RSP(RF_SET_LISTEN_MODE_ROUTING_RSP),
+    TEST_NCI_SM_EXPECT_CMD(RF_DISCOVER_MAP_CMD_A_B_F_NFCDEP),
     TEST_NCI_SM_QUEUE_RSP(RF_DISCOVER_MAP_RSP),
+    TEST_NCI_SM_EXPECT_CMD(RF_DISCOVER_CMD_A_B_F_NFCDEP),
     TEST_NCI_SM_QUEUE_RSP(RF_DISCOVER_RSP),
     TEST_NCI_SM_QUEUE_NTF(CORE_GENERIC_ERROR_NTF),  /* Ignored */
     TEST_NCI_SM_QUEUE_NTF(CORE_IGNORED_NTF),        /* Ignored */
@@ -1672,6 +2006,7 @@ static const TestSmEntry test_nci_sm_discovery_idle_discovery2[] = {
     /* But changing the mode switches SM back to IDLE */
     TEST_NCI_SM_SET_OP_MODE(NFC_OP_MODE_PEER|NFC_OP_MODE_POLL),
     TEST_NCI_SM_ASSERT_STATES(NCI_RFST_DISCOVERY, NCI_RFST_IDLE),
+    TEST_NCI_SM_EXPECT_CMD(RF_DEACTIVATE_IDLE_CMD),
     TEST_NCI_SM_QUEUE_RSP(RF_DEACTIVATE_RSP),
     TEST_NCI_SM_QUEUE_NTF(CORE_IGNORED_NTF),
     TEST_NCI_SM_WAIT_STATE(NCI_RFST_IDLE),
@@ -1679,16 +2014,21 @@ static const TestSmEntry test_nci_sm_discovery_idle_discovery2[] = {
 };
 
 static const TestSmEntry test_nci_sm_discovery_idle_failed[] = {
+    TEST_NCI_SM_EXPECT_CMD(CORE_RESET_CMD),
     TEST_NCI_SM_QUEUE_RSP(CORE_RESET_RSP),
+    TEST_NCI_SM_EXPECT_CMD(CORE_INIT_CMD_V1),
     TEST_NCI_SM_QUEUE_RSP(CORE_INIT_RSP),
-    TEST_NCI_SM_QUEUE_RSP(CORE_GET_CONFIG_RSP),
-    TEST_NCI_SM_QUEUE_RSP(CORE_SET_CONFIG_RSP),
+    TEST_NCI_SM_EXPECT_CMD(CORE_GET_CONFIG_CMD),
+    TEST_NCI_SM_QUEUE_RSP(CORE_GET_CONFIG_RSP_DEFAULT_DURATION),
 
     /* Switch state machine to DISCOVERY state */
     TEST_NCI_SM_SET_STATE(NCI_RFST_DISCOVERY),
     TEST_NCI_SM_ASSERT_STATES(NCI_STATE_INIT, NCI_RFST_DISCOVERY),
+    TEST_NCI_SM_EXPECT_CMD(RF_SET_LISTEN_MODE_ROUTING_CMD_TECHNOLOGY_A_B_F),
     TEST_NCI_SM_QUEUE_RSP(RF_SET_LISTEN_MODE_ROUTING_RSP),
+    TEST_NCI_SM_EXPECT_CMD(RF_DISCOVER_MAP_CMD_A_B_F),
     TEST_NCI_SM_QUEUE_RSP(RF_DISCOVER_MAP_RSP),
+    TEST_NCI_SM_EXPECT_CMD(RF_DISCOVER_CMD_A_B_F),
     TEST_NCI_SM_QUEUE_RSP(RF_DISCOVER_RSP),
     TEST_NCI_SM_QUEUE_NTF(CORE_CONN_CREDITS_NTF),
     TEST_NCI_SM_WAIT_STATE(NCI_RFST_DISCOVERY),
@@ -1696,44 +2036,83 @@ static const TestSmEntry test_nci_sm_discovery_idle_failed[] = {
     /* And then switch back to IDLE (and fail) */
     TEST_NCI_SM_SET_STATE(NCI_RFST_IDLE),
     TEST_NCI_SM_ASSERT_STATES(NCI_RFST_DISCOVERY, NCI_RFST_IDLE),
+    TEST_NCI_SM_EXPECT_CMD(RF_DEACTIVATE_IDLE_CMD),
     TEST_NCI_SM_QUEUE_RSP(RF_DEACTIVATE_RSP_ERROR),
     TEST_NCI_SM_WAIT_STATE(NCI_STATE_ERROR),
     TEST_NCI_SM_END()
 };
 
 static const TestSmEntry test_nci_sm_discovery_idle_broken[] = {
+    TEST_NCI_SM_EXPECT_CMD(CORE_RESET_CMD),
     TEST_NCI_SM_QUEUE_RSP(CORE_RESET_RSP),
+    TEST_NCI_SM_EXPECT_CMD(CORE_INIT_CMD_V1),
     TEST_NCI_SM_QUEUE_RSP(CORE_INIT_RSP),
-    TEST_NCI_SM_QUEUE_RSP(CORE_GET_CONFIG_RSP),
-    TEST_NCI_SM_QUEUE_RSP(CORE_SET_CONFIG_RSP),
+    TEST_NCI_SM_EXPECT_CMD(CORE_GET_CONFIG_CMD),
+    TEST_NCI_SM_QUEUE_RSP(CORE_GET_CONFIG_RSP_DEFAULT_DURATION),
 
     /* Switch state machine to DISCOVERY state */
     TEST_NCI_SM_SET_STATE(NCI_RFST_DISCOVERY),
     TEST_NCI_SM_ASSERT_STATES(NCI_STATE_INIT, NCI_RFST_DISCOVERY),
+    TEST_NCI_SM_EXPECT_CMD(RF_SET_LISTEN_MODE_ROUTING_CMD_TECHNOLOGY_A_B_F),
     TEST_NCI_SM_QUEUE_RSP(RF_SET_LISTEN_MODE_ROUTING_RSP),
+    TEST_NCI_SM_EXPECT_CMD(RF_DISCOVER_MAP_CMD_A_B_F),
     TEST_NCI_SM_QUEUE_RSP(RF_DISCOVER_MAP_RSP),
+    TEST_NCI_SM_EXPECT_CMD(RF_DISCOVER_CMD_A_B_F),
     TEST_NCI_SM_QUEUE_RSP(RF_DISCOVER_RSP),
-    TEST_NCI_SM_QUEUE_NTF(CORE_CONN_CREDITS_NTF),
     TEST_NCI_SM_WAIT_STATE(NCI_RFST_DISCOVERY),
 
     /* And then switch back to IDLE (and fail) */
     TEST_NCI_SM_SET_STATE(NCI_RFST_IDLE),
     TEST_NCI_SM_ASSERT_STATES(NCI_RFST_DISCOVERY, NCI_RFST_IDLE),
+    TEST_NCI_SM_EXPECT_CMD(RF_DEACTIVATE_IDLE_CMD),
     TEST_NCI_SM_QUEUE_RSP(RF_DEACTIVATE_RSP_BROKEN),
     TEST_NCI_SM_WAIT_STATE(NCI_STATE_ERROR),
     TEST_NCI_SM_END()
 };
 
-static const TestSmEntry test_nci_sm_discovery_poll_idle[] = {
+static const TestSmEntry test_nci_sm_discovery_idle_timeout[] = {
+    TEST_NCI_SM_SET_TIMEOUT(TEST_SHORT_TIMEOUT),
+    TEST_NCI_SM_EXPECT_CMD(CORE_RESET_CMD),
     TEST_NCI_SM_QUEUE_RSP(CORE_RESET_RSP),
+    TEST_NCI_SM_EXPECT_CMD(CORE_INIT_CMD_V1),
     TEST_NCI_SM_QUEUE_RSP(CORE_INIT_RSP),
-    TEST_NCI_SM_QUEUE_RSP(CORE_GET_CONFIG_RSP),
-    TEST_NCI_SM_QUEUE_RSP(CORE_SET_CONFIG_RSP),
+    TEST_NCI_SM_EXPECT_CMD(CORE_GET_CONFIG_CMD),
+    TEST_NCI_SM_QUEUE_RSP(CORE_GET_CONFIG_RSP_DEFAULT_DURATION),
 
     /* Switch state machine to DISCOVERY state */
     TEST_NCI_SM_SET_STATE(NCI_RFST_DISCOVERY),
+    TEST_NCI_SM_ASSERT_STATES(NCI_STATE_INIT, NCI_RFST_DISCOVERY),
+    TEST_NCI_SM_EXPECT_CMD(RF_SET_LISTEN_MODE_ROUTING_CMD_TECHNOLOGY_A_B_F),
     TEST_NCI_SM_QUEUE_RSP(RF_SET_LISTEN_MODE_ROUTING_RSP),
+    TEST_NCI_SM_EXPECT_CMD(RF_DISCOVER_MAP_CMD_A_B_F),
     TEST_NCI_SM_QUEUE_RSP(RF_DISCOVER_MAP_RSP),
+    TEST_NCI_SM_EXPECT_CMD(RF_DISCOVER_CMD_A_B_F),
+    TEST_NCI_SM_QUEUE_RSP(RF_DISCOVER_RSP),
+    TEST_NCI_SM_WAIT_STATE(NCI_RFST_DISCOVERY),
+
+    /* And then switch back to IDLE (and timeout) */
+    TEST_NCI_SM_SET_STATE(NCI_RFST_IDLE),
+    TEST_NCI_SM_ASSERT_STATES(NCI_RFST_DISCOVERY, NCI_RFST_IDLE),
+    TEST_NCI_SM_EXPECT_CMD(RF_DEACTIVATE_IDLE_CMD),
+    TEST_NCI_SM_WAIT_STATE(NCI_STATE_ERROR),
+    TEST_NCI_SM_END()
+};
+
+static const TestSmEntry test_nci_sm_discovery_poll_idle[] = {
+    TEST_NCI_SM_EXPECT_CMD(CORE_RESET_CMD),
+    TEST_NCI_SM_QUEUE_RSP(CORE_RESET_RSP),
+    TEST_NCI_SM_EXPECT_CMD(CORE_INIT_CMD_V1),
+    TEST_NCI_SM_QUEUE_RSP(CORE_INIT_RSP),
+    TEST_NCI_SM_EXPECT_CMD(CORE_GET_CONFIG_CMD),
+    TEST_NCI_SM_QUEUE_RSP(CORE_GET_CONFIG_RSP_DEFAULT_DURATION),
+
+    /* Switch state machine to DISCOVERY state */
+    TEST_NCI_SM_SET_STATE(NCI_RFST_DISCOVERY),
+    TEST_NCI_SM_EXPECT_CMD(RF_SET_LISTEN_MODE_ROUTING_CMD_TECHNOLOGY_A_B_F),
+    TEST_NCI_SM_QUEUE_RSP(RF_SET_LISTEN_MODE_ROUTING_RSP),
+    TEST_NCI_SM_EXPECT_CMD(RF_DISCOVER_MAP_CMD_A_B_F),
+    TEST_NCI_SM_QUEUE_RSP(RF_DISCOVER_MAP_RSP),
+    TEST_NCI_SM_EXPECT_CMD(RF_DISCOVER_CMD_A_B_F),
     TEST_NCI_SM_QUEUE_RSP(RF_DISCOVER_RSP),
     TEST_NCI_SM_ASSERT_STATES(NCI_STATE_INIT, NCI_RFST_DISCOVERY),
     TEST_NCI_SM_WAIT_STATE(NCI_RFST_DISCOVERY),
@@ -1749,6 +2128,7 @@ static const TestSmEntry test_nci_sm_discovery_poll_idle[] = {
 
     /* And then switch back to IDLE */
     TEST_NCI_SM_SET_STATE(NCI_RFST_IDLE),
+    TEST_NCI_SM_EXPECT_CMD(RF_DEACTIVATE_IDLE_CMD),
     TEST_NCI_SM_QUEUE_NTF(CORE_IGNORED_NTF),        /* Ignored */
     TEST_NCI_SM_QUEUE_NTF(RF_IGNORED_NTF),          /* Ignored */
     TEST_NCI_SM_QUEUE_RSP(RF_DEACTIVATE_RSP),
@@ -1760,15 +2140,20 @@ static const TestSmEntry test_nci_sm_discovery_poll_idle[] = {
 };
 
 static const TestSmEntry test_nci_sm_discovery_poll_idle_failed[] = {
+    TEST_NCI_SM_EXPECT_CMD(CORE_RESET_CMD),
     TEST_NCI_SM_QUEUE_RSP(CORE_RESET_RSP),
+    TEST_NCI_SM_EXPECT_CMD(CORE_INIT_CMD_V1),
     TEST_NCI_SM_QUEUE_RSP(CORE_INIT_RSP),
-    TEST_NCI_SM_QUEUE_RSP(CORE_GET_CONFIG_RSP),
-    TEST_NCI_SM_QUEUE_RSP(CORE_SET_CONFIG_RSP),
+    TEST_NCI_SM_EXPECT_CMD(CORE_GET_CONFIG_CMD),
+    TEST_NCI_SM_QUEUE_RSP(CORE_GET_CONFIG_RSP_DEFAULT_DURATION),
 
     /* Switch state machine to DISCOVERY state */
     TEST_NCI_SM_SET_STATE(NCI_RFST_DISCOVERY),
+    TEST_NCI_SM_EXPECT_CMD(RF_SET_LISTEN_MODE_ROUTING_CMD_TECHNOLOGY_A_B_F),
     TEST_NCI_SM_QUEUE_RSP(RF_SET_LISTEN_MODE_ROUTING_RSP),
+    TEST_NCI_SM_EXPECT_CMD(RF_DISCOVER_MAP_CMD_A_B_F),
     TEST_NCI_SM_QUEUE_RSP(RF_DISCOVER_MAP_RSP),
+    TEST_NCI_SM_EXPECT_CMD(RF_DISCOVER_CMD_A_B_F),
     TEST_NCI_SM_QUEUE_RSP(RF_DISCOVER_RSP),
     TEST_NCI_SM_ASSERT_STATES(NCI_STATE_INIT, NCI_RFST_DISCOVERY),
     TEST_NCI_SM_WAIT_STATE(NCI_RFST_DISCOVERY),
@@ -1782,21 +2167,27 @@ static const TestSmEntry test_nci_sm_discovery_poll_idle_failed[] = {
 
     /* And then switch back to IDLE (and fail) */
     TEST_NCI_SM_SET_STATE(NCI_RFST_IDLE),
+    TEST_NCI_SM_EXPECT_CMD(RF_DEACTIVATE_IDLE_CMD),
     TEST_NCI_SM_QUEUE_RSP(RF_DEACTIVATE_RSP_ERROR),
     TEST_NCI_SM_WAIT_STATE(NCI_STATE_ERROR),
     TEST_NCI_SM_END()
 };
 
 static const TestSmEntry test_nci_sm_discovery_poll_idle_broken1[] = {
+    TEST_NCI_SM_EXPECT_CMD(CORE_RESET_CMD),
     TEST_NCI_SM_QUEUE_RSP(CORE_RESET_RSP),
+    TEST_NCI_SM_EXPECT_CMD(CORE_INIT_CMD_V1),
     TEST_NCI_SM_QUEUE_RSP(CORE_INIT_RSP),
-    TEST_NCI_SM_QUEUE_RSP(CORE_GET_CONFIG_RSP),
-    TEST_NCI_SM_QUEUE_RSP(CORE_SET_CONFIG_RSP),
+    TEST_NCI_SM_EXPECT_CMD(CORE_GET_CONFIG_CMD),
+    TEST_NCI_SM_QUEUE_RSP(CORE_GET_CONFIG_RSP_DEFAULT_DURATION),
 
     /* Switch state machine to DISCOVERY state */
     TEST_NCI_SM_SET_STATE(NCI_RFST_DISCOVERY),
+    TEST_NCI_SM_EXPECT_CMD(RF_SET_LISTEN_MODE_ROUTING_CMD_TECHNOLOGY_A_B_F),
     TEST_NCI_SM_QUEUE_RSP(RF_SET_LISTEN_MODE_ROUTING_RSP),
+    TEST_NCI_SM_EXPECT_CMD(RF_DISCOVER_MAP_CMD_A_B_F),
     TEST_NCI_SM_QUEUE_RSP(RF_DISCOVER_MAP_RSP),
+    TEST_NCI_SM_EXPECT_CMD(RF_DISCOVER_CMD_A_B_F),
     TEST_NCI_SM_QUEUE_RSP(RF_DISCOVER_RSP),
     TEST_NCI_SM_ASSERT_STATES(NCI_STATE_INIT, NCI_RFST_DISCOVERY),
     TEST_NCI_SM_WAIT_STATE(NCI_RFST_DISCOVERY),
@@ -1810,21 +2201,27 @@ static const TestSmEntry test_nci_sm_discovery_poll_idle_broken1[] = {
 
     /* And then switch back to IDLE (and fail) */
     TEST_NCI_SM_SET_STATE(NCI_RFST_IDLE),
+    TEST_NCI_SM_EXPECT_CMD(RF_DEACTIVATE_IDLE_CMD),
     TEST_NCI_SM_QUEUE_RSP(RF_DEACTIVATE_RSP_BROKEN),
     TEST_NCI_SM_WAIT_STATE(NCI_STATE_ERROR),
     TEST_NCI_SM_END()
 };
 
 static const TestSmEntry test_nci_sm_discovery_poll_idle_broken2[] = {
+    TEST_NCI_SM_EXPECT_CMD(CORE_RESET_CMD),
     TEST_NCI_SM_QUEUE_RSP(CORE_RESET_RSP),
+    TEST_NCI_SM_EXPECT_CMD(CORE_INIT_CMD_V1),
     TEST_NCI_SM_QUEUE_RSP(CORE_INIT_RSP),
-    TEST_NCI_SM_QUEUE_RSP(CORE_GET_CONFIG_RSP),
-    TEST_NCI_SM_QUEUE_RSP(CORE_SET_CONFIG_RSP),
+    TEST_NCI_SM_EXPECT_CMD(CORE_GET_CONFIG_CMD),
+    TEST_NCI_SM_QUEUE_RSP(CORE_GET_CONFIG_RSP_DEFAULT_DURATION),
 
     /* Switch state machine to DISCOVERY state */
     TEST_NCI_SM_SET_STATE(NCI_RFST_DISCOVERY),
+    TEST_NCI_SM_EXPECT_CMD(RF_SET_LISTEN_MODE_ROUTING_CMD_TECHNOLOGY_A_B_F),
     TEST_NCI_SM_QUEUE_RSP(RF_SET_LISTEN_MODE_ROUTING_RSP),
+    TEST_NCI_SM_EXPECT_CMD(RF_DISCOVER_MAP_CMD_A_B_F),
     TEST_NCI_SM_QUEUE_RSP(RF_DISCOVER_MAP_RSP),
+    TEST_NCI_SM_EXPECT_CMD(RF_DISCOVER_CMD_A_B_F),
     TEST_NCI_SM_QUEUE_RSP(RF_DISCOVER_RSP),
     TEST_NCI_SM_ASSERT_STATES(NCI_STATE_INIT, NCI_RFST_DISCOVERY),
     TEST_NCI_SM_WAIT_STATE(NCI_RFST_DISCOVERY),
@@ -1838,6 +2235,7 @@ static const TestSmEntry test_nci_sm_discovery_poll_idle_broken2[] = {
 
     /* And then switch back to IDLE (and fail) */
     TEST_NCI_SM_SET_STATE(NCI_RFST_IDLE),
+    TEST_NCI_SM_EXPECT_CMD(RF_DEACTIVATE_IDLE_CMD),
     TEST_NCI_SM_QUEUE_RSP(RF_DEACTIVATE_RSP),
     TEST_NCI_SM_QUEUE_NTF(RF_DEACTIVATE_NTF_BROKEN),
     TEST_NCI_SM_WAIT_STATE(NCI_STATE_ERROR),
@@ -1845,12 +2243,17 @@ static const TestSmEntry test_nci_sm_discovery_poll_idle_broken2[] = {
 };
 
 static const TestSmEntry test_nci_sm_discovery_poll_discovery[] = {
+    TEST_NCI_SM_EXPECT_CMD(CORE_RESET_CMD),
     TEST_NCI_SM_QUEUE_RSP(CORE_RESET_RSP),
+    TEST_NCI_SM_EXPECT_CMD(CORE_INIT_CMD_V1),
     TEST_NCI_SM_QUEUE_RSP(CORE_INIT_RSP),
-    TEST_NCI_SM_QUEUE_RSP(CORE_GET_CONFIG_RSP),
-    TEST_NCI_SM_QUEUE_RSP(CORE_SET_CONFIG_RSP),
+    TEST_NCI_SM_EXPECT_CMD(CORE_GET_CONFIG_CMD),
+    TEST_NCI_SM_QUEUE_RSP(CORE_GET_CONFIG_RSP_DEFAULT_DURATION),
+    TEST_NCI_SM_EXPECT_CMD(RF_SET_LISTEN_MODE_ROUTING_CMD_TECHNOLOGY_A_B_F),
     TEST_NCI_SM_QUEUE_RSP(RF_SET_LISTEN_MODE_ROUTING_RSP),
+    TEST_NCI_SM_EXPECT_CMD(RF_DISCOVER_MAP_CMD_A_B_F),
     TEST_NCI_SM_QUEUE_RSP(RF_DISCOVER_MAP_RSP),
+    TEST_NCI_SM_EXPECT_CMD(RF_DISCOVER_CMD_A_B_F),
     TEST_NCI_SM_QUEUE_RSP(RF_DISCOVER_RSP),
 
     /* Switch state machine to DISCOVERY state */
@@ -1874,6 +2277,7 @@ static const TestSmEntry test_nci_sm_discovery_poll_discovery[] = {
 
     /* And then switch back to DISCOVERY */
     TEST_NCI_SM_SET_STATE(NCI_RFST_DISCOVERY),
+    TEST_NCI_SM_EXPECT_CMD(RF_DEACTIVATE_DISCOVERY_CMD),
     TEST_NCI_SM_QUEUE_RSP(RF_DEACTIVATE_RSP),
     TEST_NCI_SM_QUEUE_NTF(CORE_IGNORED_NTF),  /* Ignored */
     TEST_NCI_SM_QUEUE_NTF(RF_IGNORED_NTF),  /* Ignored */
@@ -1888,6 +2292,7 @@ static const TestSmEntry test_nci_sm_discovery_poll_discovery[] = {
 
     /* And then to IDLE */
     TEST_NCI_SM_SET_STATE(NCI_RFST_IDLE),
+    TEST_NCI_SM_EXPECT_CMD(RF_DEACTIVATE_IDLE_CMD),
     TEST_NCI_SM_QUEUE_RSP(RF_DEACTIVATE_RSP),
     TEST_NCI_SM_QUEUE_NTF(RF_DEACTIVATE_NTF_IDLE),
     TEST_NCI_SM_WAIT_STATE(NCI_RFST_IDLE),
@@ -1895,15 +2300,20 @@ static const TestSmEntry test_nci_sm_discovery_poll_discovery[] = {
 };
 
 static const TestSmEntry test_nci_sm_dscvr_poll_dscvr_error1[] = {
+    TEST_NCI_SM_EXPECT_CMD(CORE_RESET_CMD),
     TEST_NCI_SM_QUEUE_RSP(CORE_RESET_RSP),
+    TEST_NCI_SM_EXPECT_CMD(CORE_INIT_CMD_V1),
     TEST_NCI_SM_QUEUE_RSP(CORE_INIT_RSP),
-    TEST_NCI_SM_QUEUE_RSP(CORE_GET_CONFIG_RSP),
-    TEST_NCI_SM_QUEUE_RSP(CORE_SET_CONFIG_RSP),
+    TEST_NCI_SM_EXPECT_CMD(CORE_GET_CONFIG_CMD),
+    TEST_NCI_SM_QUEUE_RSP(CORE_GET_CONFIG_RSP_DEFAULT_DURATION),
 
     /* Switch state machine to DISCOVERY state */
     TEST_NCI_SM_SET_STATE(NCI_RFST_DISCOVERY),
+    TEST_NCI_SM_EXPECT_CMD(RF_SET_LISTEN_MODE_ROUTING_CMD_TECHNOLOGY_A_B_F),
     TEST_NCI_SM_QUEUE_RSP(RF_SET_LISTEN_MODE_ROUTING_RSP),
+    TEST_NCI_SM_EXPECT_CMD(RF_DISCOVER_MAP_CMD_A_B_F),
     TEST_NCI_SM_QUEUE_RSP(RF_DISCOVER_MAP_RSP),
+    TEST_NCI_SM_EXPECT_CMD(RF_DISCOVER_CMD_A_B_F),
     TEST_NCI_SM_QUEUE_RSP(RF_DISCOVER_RSP),
     TEST_NCI_SM_WAIT_STATE(NCI_RFST_DISCOVERY),
 
@@ -1915,24 +2325,31 @@ static const TestSmEntry test_nci_sm_dscvr_poll_dscvr_error1[] = {
 
     /* And then switch back to DISCOVERY (and fail) */
     TEST_NCI_SM_SET_STATE(NCI_RFST_DISCOVERY),
+    TEST_NCI_SM_EXPECT_CMD(RF_DEACTIVATE_DISCOVERY_CMD),
     TEST_NCI_SM_QUEUE_RSP(RF_DEACTIVATE_RSP_ERROR), /* Fail to Discovery */
 
     /* Switch to to Idle instead */
+    TEST_NCI_SM_EXPECT_CMD(RF_DEACTIVATE_IDLE_CMD),
     TEST_NCI_SM_QUEUE_RSP(RF_DEACTIVATE_RSP),
     TEST_NCI_SM_WAIT_STATE(NCI_RFST_IDLE),
     TEST_NCI_SM_END()
 };
 
 static const TestSmEntry test_nci_sm_dscvr_poll_dscvr_error2[] = {
+    TEST_NCI_SM_EXPECT_CMD(CORE_RESET_CMD),
     TEST_NCI_SM_QUEUE_RSP(CORE_RESET_RSP),
+    TEST_NCI_SM_EXPECT_CMD(CORE_INIT_CMD_V1),
     TEST_NCI_SM_QUEUE_RSP(CORE_INIT_RSP),
-    TEST_NCI_SM_QUEUE_RSP(CORE_GET_CONFIG_RSP),
-    TEST_NCI_SM_QUEUE_RSP(CORE_SET_CONFIG_RSP),
+    TEST_NCI_SM_EXPECT_CMD(CORE_GET_CONFIG_CMD),
+    TEST_NCI_SM_QUEUE_RSP(CORE_GET_CONFIG_RSP_DEFAULT_DURATION),
 
     /* Switch state machine to DISCOVERY state */
     TEST_NCI_SM_SET_STATE(NCI_RFST_DISCOVERY),
+    TEST_NCI_SM_EXPECT_CMD(RF_SET_LISTEN_MODE_ROUTING_CMD_TECHNOLOGY_A_B_F),
     TEST_NCI_SM_QUEUE_RSP(RF_SET_LISTEN_MODE_ROUTING_RSP),
+    TEST_NCI_SM_EXPECT_CMD(RF_DISCOVER_MAP_CMD_A_B_F),
     TEST_NCI_SM_QUEUE_RSP(RF_DISCOVER_MAP_RSP),
+    TEST_NCI_SM_EXPECT_CMD(RF_DISCOVER_CMD_A_B_F),
     TEST_NCI_SM_QUEUE_RSP(RF_DISCOVER_RSP),
     TEST_NCI_SM_WAIT_STATE(NCI_RFST_DISCOVERY),
 
@@ -1944,22 +2361,29 @@ static const TestSmEntry test_nci_sm_dscvr_poll_dscvr_error2[] = {
 
     /* And then switch back to DISCOVERY (and fail) */
     TEST_NCI_SM_SET_STATE(NCI_RFST_DISCOVERY),
+    TEST_NCI_SM_EXPECT_CMD(RF_DEACTIVATE_DISCOVERY_CMD),
     TEST_NCI_SM_QUEUE_RSP(RF_DEACTIVATE_RSP_ERROR), /* Fail to Discovery */
+    TEST_NCI_SM_EXPECT_CMD(RF_DEACTIVATE_IDLE_CMD),
     TEST_NCI_SM_QUEUE_RSP(RF_DEACTIVATE_RSP_ERROR), /* Fail to Idle */
     TEST_NCI_SM_WAIT_STATE(NCI_STATE_ERROR),
     TEST_NCI_SM_END()
 };
 
 static const TestSmEntry test_nci_sm_dscvr_poll_dscvr_error3[] = {
+    TEST_NCI_SM_EXPECT_CMD(CORE_RESET_CMD),
     TEST_NCI_SM_QUEUE_RSP(CORE_RESET_RSP),
+    TEST_NCI_SM_EXPECT_CMD(CORE_INIT_CMD_V1),
     TEST_NCI_SM_QUEUE_RSP(CORE_INIT_RSP),
-    TEST_NCI_SM_QUEUE_RSP(CORE_GET_CONFIG_RSP),
-    TEST_NCI_SM_QUEUE_RSP(CORE_SET_CONFIG_RSP),
+    TEST_NCI_SM_EXPECT_CMD(CORE_GET_CONFIG_CMD),
+    TEST_NCI_SM_QUEUE_RSP(CORE_GET_CONFIG_RSP_DEFAULT_DURATION),
 
     /* Switch state machine to DISCOVERY state */
     TEST_NCI_SM_SET_STATE(NCI_RFST_DISCOVERY),
+    TEST_NCI_SM_EXPECT_CMD(RF_SET_LISTEN_MODE_ROUTING_CMD_TECHNOLOGY_A_B_F),
     TEST_NCI_SM_QUEUE_RSP(RF_SET_LISTEN_MODE_ROUTING_RSP),
+    TEST_NCI_SM_EXPECT_CMD(RF_DISCOVER_MAP_CMD_A_B_F),
     TEST_NCI_SM_QUEUE_RSP(RF_DISCOVER_MAP_RSP),
+    TEST_NCI_SM_EXPECT_CMD(RF_DISCOVER_CMD_A_B_F),
     TEST_NCI_SM_QUEUE_RSP(RF_DISCOVER_RSP),
     TEST_NCI_SM_WAIT_STATE(NCI_RFST_DISCOVERY),
 
@@ -1971,22 +2395,29 @@ static const TestSmEntry test_nci_sm_dscvr_poll_dscvr_error3[] = {
 
     /* And then switch back to DISCOVERY (and fail) */
     TEST_NCI_SM_SET_STATE(NCI_RFST_DISCOVERY),
+    TEST_NCI_SM_EXPECT_CMD(RF_DEACTIVATE_DISCOVERY_CMD),
     TEST_NCI_SM_QUEUE_RSP(RF_DEACTIVATE_RSP_ERROR), /* Fail to Discovery */
+    TEST_NCI_SM_EXPECT_CMD(RF_DEACTIVATE_IDLE_CMD),
     TEST_NCI_SM_QUEUE_RSP(RF_DEACTIVATE_RSP_BROKEN), /* Fail to Idle */
     TEST_NCI_SM_WAIT_STATE(NCI_STATE_ERROR),
     TEST_NCI_SM_END()
 };
 
 static const TestSmEntry test_nci_sm_dscvr_poll_dscvr_broken[] = {
+    TEST_NCI_SM_EXPECT_CMD(CORE_RESET_CMD),
     TEST_NCI_SM_QUEUE_RSP(CORE_RESET_RSP),
+    TEST_NCI_SM_EXPECT_CMD(CORE_INIT_CMD_V1),
     TEST_NCI_SM_QUEUE_RSP(CORE_INIT_RSP),
-    TEST_NCI_SM_QUEUE_RSP(CORE_GET_CONFIG_RSP),
-    TEST_NCI_SM_QUEUE_RSP(CORE_SET_CONFIG_RSP),
+    TEST_NCI_SM_EXPECT_CMD(CORE_GET_CONFIG_CMD),
+    TEST_NCI_SM_QUEUE_RSP(CORE_GET_CONFIG_RSP_DEFAULT_DURATION),
 
     /* Switch state machine to DISCOVERY state */
     TEST_NCI_SM_SET_STATE(NCI_RFST_DISCOVERY),
+    TEST_NCI_SM_EXPECT_CMD(RF_SET_LISTEN_MODE_ROUTING_CMD_TECHNOLOGY_A_B_F),
     TEST_NCI_SM_QUEUE_RSP(RF_SET_LISTEN_MODE_ROUTING_RSP),
+    TEST_NCI_SM_EXPECT_CMD(RF_DISCOVER_MAP_CMD_A_B_F),
     TEST_NCI_SM_QUEUE_RSP(RF_DISCOVER_MAP_RSP),
+    TEST_NCI_SM_EXPECT_CMD(RF_DISCOVER_CMD_A_B_F),
     TEST_NCI_SM_QUEUE_RSP(RF_DISCOVER_RSP),
     TEST_NCI_SM_WAIT_STATE(NCI_RFST_DISCOVERY),
 
@@ -1998,7 +2429,9 @@ static const TestSmEntry test_nci_sm_dscvr_poll_dscvr_broken[] = {
 
     /* And then switch back to DISCOVERY (and fail) */
     TEST_NCI_SM_SET_STATE(NCI_RFST_DISCOVERY),
+    TEST_NCI_SM_EXPECT_CMD(RF_DEACTIVATE_DISCOVERY_CMD),
     TEST_NCI_SM_QUEUE_RSP(RF_DEACTIVATE_RSP_ERROR), /* Fail to Discovery */
+    TEST_NCI_SM_EXPECT_CMD(RF_DEACTIVATE_IDLE_CMD),
     TEST_NCI_SM_QUEUE_RSP(RF_DEACTIVATE_RSP_ERROR), /* Fail to Idle */
     TEST_NCI_SM_WAIT_STATE(NCI_STATE_ERROR),
     TEST_NCI_SM_END()
@@ -2015,14 +2448,19 @@ static const guint8 READ_RESP[] = {
 };
 
 static const TestSmEntry test_nci_sm_dscvr_poll_read_dscvr[] = {
+    TEST_NCI_SM_EXPECT_CMD(CORE_RESET_CMD),
     TEST_NCI_SM_QUEUE_RSP(CORE_RESET_RSP),
+    TEST_NCI_SM_EXPECT_CMD(CORE_INIT_CMD_V1),
     TEST_NCI_SM_QUEUE_RSP(CORE_INIT_RSP),
-    TEST_NCI_SM_QUEUE_RSP(CORE_GET_CONFIG_RSP),
-    TEST_NCI_SM_QUEUE_RSP(CORE_SET_CONFIG_RSP),
+    TEST_NCI_SM_EXPECT_CMD(CORE_GET_CONFIG_CMD),
+    TEST_NCI_SM_QUEUE_RSP(CORE_GET_CONFIG_RSP_DEFAULT_DURATION),
 
     /* Switch state machine to DISCOVERY state */
+    TEST_NCI_SM_EXPECT_CMD(RF_SET_LISTEN_MODE_ROUTING_CMD_TECHNOLOGY_A_B_F),
     TEST_NCI_SM_QUEUE_RSP(RF_SET_LISTEN_MODE_ROUTING_RSP),
+    TEST_NCI_SM_EXPECT_CMD(RF_DISCOVER_MAP_CMD_A_B_F),
     TEST_NCI_SM_QUEUE_RSP(RF_DISCOVER_MAP_RSP),
+    TEST_NCI_SM_EXPECT_CMD(RF_DISCOVER_CMD_A_B_F),
     TEST_NCI_SM_QUEUE_RSP(RF_DISCOVER_RSP),
     TEST_NCI_SM_SET_STATE(NCI_RFST_DISCOVERY),
     TEST_NCI_SM_ASSERT_STATES(NCI_STATE_INIT, NCI_RFST_DISCOVERY),
@@ -2040,22 +2478,28 @@ static const TestSmEntry test_nci_sm_dscvr_poll_read_dscvr[] = {
     TEST_NCI_SM_QUEUE_NTF(READ_RESP),
 
     /* Deactivate to DISCOVERY */
-    TEST_NCI_SM_QUEUE_RSP(RF_DEACTIVATE_RSP),
     TEST_NCI_SM_SET_STATE(NCI_RFST_DISCOVERY),
+    TEST_NCI_SM_EXPECT_CMD(RF_DEACTIVATE_DISCOVERY_CMD),
+    TEST_NCI_SM_QUEUE_RSP(RF_DEACTIVATE_RSP),
     TEST_NCI_SM_QUEUE_NTF(RF_DEACTIVATE_NTF_DISCOVERY),
     TEST_NCI_SM_WAIT_STATE(NCI_RFST_DISCOVERY),
     TEST_NCI_SM_END()
 };
 
 static const TestSmEntry test_nci_sm_dscvr_poll_deact_t4a[] = {
+    TEST_NCI_SM_EXPECT_CMD(CORE_RESET_CMD),
     TEST_NCI_SM_QUEUE_RSP(CORE_RESET_RSP),
+    TEST_NCI_SM_EXPECT_CMD(CORE_INIT_CMD_V1),
     TEST_NCI_SM_QUEUE_RSP(CORE_INIT_RSP),
-    TEST_NCI_SM_QUEUE_RSP(CORE_GET_CONFIG_RSP),
-    TEST_NCI_SM_QUEUE_RSP(CORE_SET_CONFIG_RSP),
+    TEST_NCI_SM_EXPECT_CMD(CORE_GET_CONFIG_CMD),
+    TEST_NCI_SM_QUEUE_RSP(CORE_GET_CONFIG_RSP_DEFAULT_DURATION),
 
     /* Switch state machine to DISCOVERY state */
+    TEST_NCI_SM_EXPECT_CMD(RF_SET_LISTEN_MODE_ROUTING_CMD_TECHNOLOGY_A_B_F),
     TEST_NCI_SM_QUEUE_RSP(RF_SET_LISTEN_MODE_ROUTING_RSP),
+    TEST_NCI_SM_EXPECT_CMD(RF_DISCOVER_MAP_CMD_A_B_F),
     TEST_NCI_SM_QUEUE_RSP(RF_DISCOVER_MAP_RSP),
+    TEST_NCI_SM_EXPECT_CMD(RF_DISCOVER_CMD_A_B_F),
     TEST_NCI_SM_QUEUE_RSP(RF_DISCOVER_RSP),
     TEST_NCI_SM_SET_STATE(NCI_RFST_DISCOVERY),
     TEST_NCI_SM_WAIT_STATE(NCI_RFST_DISCOVERY),
@@ -2074,6 +2518,7 @@ static const TestSmEntry test_nci_sm_dscvr_poll_deact_t4a[] = {
 
     /* This one does */
     TEST_NCI_SM_QUEUE_NTF(CORE_INTERFACE_TRANSMISSION_ERROR_NTF),
+    TEST_NCI_SM_EXPECT_CMD(RF_DEACTIVATE_DISCOVERY_CMD),
     TEST_NCI_SM_QUEUE_RSP(RF_DEACTIVATE_RSP),
     TEST_NCI_SM_QUEUE_NTF(RF_DEACTIVATE_NTF_DISCOVERY),
     TEST_NCI_SM_WAIT_STATE(NCI_RFST_DISCOVERY),
@@ -2086,6 +2531,7 @@ static const TestSmEntry test_nci_sm_dscvr_poll_deact_t4a[] = {
 
     /* Back to DISCOVERY */
     TEST_NCI_SM_QUEUE_NTF(CORE_INTERFACE_PROTOCOL_ERROR_NTF),
+    TEST_NCI_SM_EXPECT_CMD(RF_DEACTIVATE_DISCOVERY_CMD),
     TEST_NCI_SM_QUEUE_RSP(RF_DEACTIVATE_RSP),
     TEST_NCI_SM_QUEUE_NTF(RF_DEACTIVATE_NTF_DISCOVERY),
     TEST_NCI_SM_WAIT_STATE(NCI_RFST_DISCOVERY),
@@ -2098,6 +2544,7 @@ static const TestSmEntry test_nci_sm_dscvr_poll_deact_t4a[] = {
 
     /* Back to DISCOVERY */
     TEST_NCI_SM_QUEUE_NTF(CORE_INTERFACE_TIMEOUT_ERROR_NTF),
+    TEST_NCI_SM_EXPECT_CMD(RF_DEACTIVATE_DISCOVERY_CMD),
     TEST_NCI_SM_QUEUE_RSP(RF_DEACTIVATE_RSP),
     TEST_NCI_SM_QUEUE_NTF(RF_DEACTIVATE_NTF_DISCOVERY),
     TEST_NCI_SM_WAIT_STATE(NCI_RFST_DISCOVERY),
@@ -2110,6 +2557,7 @@ static const TestSmEntry test_nci_sm_dscvr_poll_deact_t4a[] = {
 
     /* Back to DISCOVERY */
     TEST_NCI_SM_QUEUE_NTF(CORE_INTERFACE_SYNTAX_ERROR_NTF),
+    TEST_NCI_SM_EXPECT_CMD(RF_DEACTIVATE_DISCOVERY_CMD),
     TEST_NCI_SM_QUEUE_RSP(RF_DEACTIVATE_RSP),
     TEST_NCI_SM_QUEUE_NTF(RF_DEACTIVATE_NTF_DISCOVERY),
     TEST_NCI_SM_WAIT_STATE(NCI_RFST_DISCOVERY),
@@ -2123,6 +2571,7 @@ static const TestSmEntry test_nci_sm_dscvr_poll_deact_t4a[] = {
     /* Deactivate to IDLE */
     TEST_NCI_SM_SET_STATE(NCI_RFST_IDLE),
     TEST_NCI_SM_ASSERT_STATES(NCI_RFST_POLL_ACTIVE, NCI_RFST_IDLE),
+    TEST_NCI_SM_EXPECT_CMD(RF_DEACTIVATE_IDLE_CMD),
     TEST_NCI_SM_QUEUE_RSP(RF_DEACTIVATE_RSP),
     TEST_NCI_SM_QUEUE_NTF(RF_DEACTIVATE_NTF_IDLE),
     TEST_NCI_SM_WAIT_STATE(NCI_RFST_IDLE),
@@ -2130,14 +2579,19 @@ static const TestSmEntry test_nci_sm_dscvr_poll_deact_t4a[] = {
 };
 
 static const TestSmEntry test_nci_sm_dscvr_poll_act_error1[] = {
+    TEST_NCI_SM_EXPECT_CMD(CORE_RESET_CMD),
     TEST_NCI_SM_QUEUE_RSP(CORE_RESET_RSP),
+    TEST_NCI_SM_EXPECT_CMD(CORE_INIT_CMD_V1),
     TEST_NCI_SM_QUEUE_RSP(CORE_INIT_RSP),
-    TEST_NCI_SM_QUEUE_RSP(CORE_GET_CONFIG_RSP),
-    TEST_NCI_SM_QUEUE_RSP(CORE_SET_CONFIG_RSP),
+    TEST_NCI_SM_EXPECT_CMD(CORE_GET_CONFIG_CMD),
+    TEST_NCI_SM_QUEUE_RSP(CORE_GET_CONFIG_RSP_DEFAULT_DURATION),
 
     /* Switch state machine to DISCOVERY state */
+    TEST_NCI_SM_EXPECT_CMD(RF_SET_LISTEN_MODE_ROUTING_CMD_TECHNOLOGY_A_B_F),
     TEST_NCI_SM_QUEUE_RSP(RF_SET_LISTEN_MODE_ROUTING_RSP),
+    TEST_NCI_SM_EXPECT_CMD(RF_DISCOVER_MAP_CMD_A_B_F),
     TEST_NCI_SM_QUEUE_RSP(RF_DISCOVER_MAP_RSP),
+    TEST_NCI_SM_EXPECT_CMD(RF_DISCOVER_CMD_A_B_F),
     TEST_NCI_SM_QUEUE_RSP(RF_DISCOVER_RSP),
     TEST_NCI_SM_SET_STATE(NCI_RFST_DISCOVERY),
     TEST_NCI_SM_WAIT_STATE(NCI_RFST_DISCOVERY),
@@ -2145,6 +2599,7 @@ static const TestSmEntry test_nci_sm_dscvr_poll_act_error1[] = {
     /* Broken activation switches state machine to DISCOVERY */
     TEST_NCI_SM_QUEUE_NTF(RF_INTF_ACTIVATED_NTF_T2_BROKEN1),
     TEST_NCI_SM_WAIT_STATE(NCI_RFST_POLL_ACTIVE),
+    TEST_NCI_SM_EXPECT_CMD(RF_DEACTIVATE_DISCOVERY_CMD),
     TEST_NCI_SM_QUEUE_RSP(RF_DEACTIVATE_RSP),
     TEST_NCI_SM_QUEUE_NTF(RF_DEACTIVATE_NTF_DISCOVERY),
     TEST_NCI_SM_WAIT_STATE(NCI_RFST_DISCOVERY),
@@ -2152,14 +2607,19 @@ static const TestSmEntry test_nci_sm_dscvr_poll_act_error1[] = {
 };
 
 static const TestSmEntry test_nci_sm_dscvr_poll_act_error2[] = {
+    TEST_NCI_SM_EXPECT_CMD(CORE_RESET_CMD),
     TEST_NCI_SM_QUEUE_RSP(CORE_RESET_RSP),
+    TEST_NCI_SM_EXPECT_CMD(CORE_INIT_CMD_V1),
     TEST_NCI_SM_QUEUE_RSP(CORE_INIT_RSP),
-    TEST_NCI_SM_QUEUE_RSP(CORE_GET_CONFIG_RSP),
-    TEST_NCI_SM_QUEUE_RSP(CORE_SET_CONFIG_RSP),
+    TEST_NCI_SM_EXPECT_CMD(CORE_GET_CONFIG_CMD),
+    TEST_NCI_SM_QUEUE_RSP(CORE_GET_CONFIG_RSP_DEFAULT_DURATION),
 
     /* Switch state machine to DISCOVERY state */
+    TEST_NCI_SM_EXPECT_CMD(RF_SET_LISTEN_MODE_ROUTING_CMD_TECHNOLOGY_A_B_F),
     TEST_NCI_SM_QUEUE_RSP(RF_SET_LISTEN_MODE_ROUTING_RSP),
+    TEST_NCI_SM_EXPECT_CMD(RF_DISCOVER_MAP_CMD_A_B_F),
     TEST_NCI_SM_QUEUE_RSP(RF_DISCOVER_MAP_RSP),
+    TEST_NCI_SM_EXPECT_CMD(RF_DISCOVER_CMD_A_B_F),
     TEST_NCI_SM_QUEUE_RSP(RF_DISCOVER_RSP),
     TEST_NCI_SM_SET_STATE(NCI_RFST_DISCOVERY),
     TEST_NCI_SM_WAIT_STATE(NCI_RFST_DISCOVERY),
@@ -2167,6 +2627,7 @@ static const TestSmEntry test_nci_sm_dscvr_poll_act_error2[] = {
     /* Broken activation switches state machine to DISCOVERY */
     TEST_NCI_SM_QUEUE_NTF(RF_INTF_ACTIVATED_NTF_T2_BROKEN2),
     TEST_NCI_SM_WAIT_STATE(NCI_RFST_POLL_ACTIVE),
+    TEST_NCI_SM_EXPECT_CMD(RF_DEACTIVATE_DISCOVERY_CMD),
     TEST_NCI_SM_QUEUE_RSP(RF_DEACTIVATE_RSP),
     TEST_NCI_SM_QUEUE_NTF(RF_DEACTIVATE_NTF_DISCOVERY),
     TEST_NCI_SM_WAIT_STATE(NCI_RFST_DISCOVERY),
@@ -2174,14 +2635,19 @@ static const TestSmEntry test_nci_sm_dscvr_poll_act_error2[] = {
 };
 
 static const TestSmEntry test_nci_sm_dscvr_poll_act_error3[] = {
+    TEST_NCI_SM_EXPECT_CMD(CORE_RESET_CMD),
     TEST_NCI_SM_QUEUE_RSP(CORE_RESET_RSP),
+    TEST_NCI_SM_EXPECT_CMD(CORE_INIT_CMD_V1),
     TEST_NCI_SM_QUEUE_RSP(CORE_INIT_RSP),
-    TEST_NCI_SM_QUEUE_RSP(CORE_GET_CONFIG_RSP),
-    TEST_NCI_SM_QUEUE_RSP(CORE_SET_CONFIG_RSP),
+    TEST_NCI_SM_EXPECT_CMD(CORE_GET_CONFIG_CMD),
+    TEST_NCI_SM_QUEUE_RSP(CORE_GET_CONFIG_RSP_DEFAULT_DURATION),
 
     /* Switch state machine to DISCOVERY state */
+    TEST_NCI_SM_EXPECT_CMD(RF_SET_LISTEN_MODE_ROUTING_CMD_TECHNOLOGY_A_B_F),
     TEST_NCI_SM_QUEUE_RSP(RF_SET_LISTEN_MODE_ROUTING_RSP),
+    TEST_NCI_SM_EXPECT_CMD(RF_DISCOVER_MAP_CMD_A_B_F),
     TEST_NCI_SM_QUEUE_RSP(RF_DISCOVER_MAP_RSP),
+    TEST_NCI_SM_EXPECT_CMD(RF_DISCOVER_CMD_A_B_F),
     TEST_NCI_SM_QUEUE_RSP(RF_DISCOVER_RSP),
     TEST_NCI_SM_SET_STATE(NCI_RFST_DISCOVERY),
     TEST_NCI_SM_WAIT_STATE(NCI_RFST_DISCOVERY),
@@ -2189,6 +2655,7 @@ static const TestSmEntry test_nci_sm_dscvr_poll_act_error3[] = {
     /* Broken activation switches state machine to DISCOVERY */
     TEST_NCI_SM_QUEUE_NTF(RF_INTF_ACTIVATED_NTF_T2_BROKEN3),
     TEST_NCI_SM_WAIT_STATE(NCI_RFST_POLL_ACTIVE),
+    TEST_NCI_SM_EXPECT_CMD(RF_DEACTIVATE_DISCOVERY_CMD),
     TEST_NCI_SM_QUEUE_RSP(RF_DEACTIVATE_RSP),
     TEST_NCI_SM_QUEUE_NTF(RF_DEACTIVATE_NTF_DISCOVERY),
     TEST_NCI_SM_WAIT_STATE(NCI_RFST_DISCOVERY),
@@ -2196,14 +2663,19 @@ static const TestSmEntry test_nci_sm_dscvr_poll_act_error3[] = {
 };
 
 static const TestSmEntry test_nci_sm_dscvr_poll_act_error4[] = {
+    TEST_NCI_SM_EXPECT_CMD(CORE_RESET_CMD),
     TEST_NCI_SM_QUEUE_RSP(CORE_RESET_RSP),
+    TEST_NCI_SM_EXPECT_CMD(CORE_INIT_CMD_V1),
     TEST_NCI_SM_QUEUE_RSP(CORE_INIT_RSP),
-    TEST_NCI_SM_QUEUE_RSP(CORE_GET_CONFIG_RSP),
-    TEST_NCI_SM_QUEUE_RSP(CORE_SET_CONFIG_RSP),
+    TEST_NCI_SM_EXPECT_CMD(CORE_GET_CONFIG_CMD),
+    TEST_NCI_SM_QUEUE_RSP(CORE_GET_CONFIG_RSP_DEFAULT_DURATION),
 
     /* Switch state machine to DISCOVERY state */
+    TEST_NCI_SM_EXPECT_CMD(RF_SET_LISTEN_MODE_ROUTING_CMD_TECHNOLOGY_A_B_F),
     TEST_NCI_SM_QUEUE_RSP(RF_SET_LISTEN_MODE_ROUTING_RSP),
+    TEST_NCI_SM_EXPECT_CMD(RF_DISCOVER_MAP_CMD_A_B_F),
     TEST_NCI_SM_QUEUE_RSP(RF_DISCOVER_MAP_RSP),
+    TEST_NCI_SM_EXPECT_CMD(RF_DISCOVER_CMD_A_B_F),
     TEST_NCI_SM_QUEUE_RSP(RF_DISCOVER_RSP),
     TEST_NCI_SM_SET_STATE(NCI_RFST_DISCOVERY),
     TEST_NCI_SM_WAIT_STATE(NCI_RFST_DISCOVERY),
@@ -2211,6 +2683,7 @@ static const TestSmEntry test_nci_sm_dscvr_poll_act_error4[] = {
     /* Broken activation switches state machine to DISCOVERY */
     TEST_NCI_SM_QUEUE_NTF(RF_INTF_ACTIVATED_NTF_T4A_BROKEN1),
     TEST_NCI_SM_WAIT_STATE(NCI_RFST_POLL_ACTIVE),
+    TEST_NCI_SM_EXPECT_CMD(RF_DEACTIVATE_DISCOVERY_CMD),
     TEST_NCI_SM_QUEUE_RSP(RF_DEACTIVATE_RSP),
     TEST_NCI_SM_QUEUE_NTF(RF_DEACTIVATE_NTF_DISCOVERY),
     TEST_NCI_SM_WAIT_STATE(NCI_RFST_DISCOVERY),
@@ -2218,14 +2691,19 @@ static const TestSmEntry test_nci_sm_dscvr_poll_act_error4[] = {
 };
 
 static const TestSmEntry test_nci_sm_dscvr_poll_deact_t4a_badparam1[] = {
+    TEST_NCI_SM_EXPECT_CMD(CORE_RESET_CMD),
     TEST_NCI_SM_QUEUE_RSP(CORE_RESET_RSP),
+    TEST_NCI_SM_EXPECT_CMD(CORE_INIT_CMD_V1),
     TEST_NCI_SM_QUEUE_RSP(CORE_INIT_RSP),
-    TEST_NCI_SM_QUEUE_RSP(CORE_GET_CONFIG_RSP),
-    TEST_NCI_SM_QUEUE_RSP(CORE_SET_CONFIG_RSP),
+    TEST_NCI_SM_EXPECT_CMD(CORE_GET_CONFIG_CMD),
+    TEST_NCI_SM_QUEUE_RSP(CORE_GET_CONFIG_RSP_DEFAULT_DURATION),
 
     /* Switch state machine to DISCOVERY state */
+    TEST_NCI_SM_EXPECT_CMD(RF_SET_LISTEN_MODE_ROUTING_CMD_TECHNOLOGY_A_B_F),
     TEST_NCI_SM_QUEUE_RSP(RF_SET_LISTEN_MODE_ROUTING_RSP),
+    TEST_NCI_SM_EXPECT_CMD(RF_DISCOVER_MAP_CMD_A_B_F),
     TEST_NCI_SM_QUEUE_RSP(RF_DISCOVER_MAP_RSP),
+    TEST_NCI_SM_EXPECT_CMD(RF_DISCOVER_CMD_A_B_F),
     TEST_NCI_SM_QUEUE_RSP(RF_DISCOVER_RSP),
     TEST_NCI_SM_SET_STATE(NCI_RFST_DISCOVERY),
     TEST_NCI_SM_WAIT_STATE(NCI_RFST_DISCOVERY),
@@ -2239,6 +2717,7 @@ static const TestSmEntry test_nci_sm_dscvr_poll_deact_t4a_badparam1[] = {
     /* Deactivate to IDLE */
     TEST_NCI_SM_SET_STATE(NCI_RFST_IDLE),
     TEST_NCI_SM_ASSERT_STATES(NCI_RFST_POLL_ACTIVE, NCI_RFST_IDLE),
+    TEST_NCI_SM_EXPECT_CMD(RF_DEACTIVATE_IDLE_CMD),
     TEST_NCI_SM_QUEUE_RSP(RF_DEACTIVATE_RSP),
     TEST_NCI_SM_QUEUE_NTF(RF_DEACTIVATE_NTF_IDLE),
     TEST_NCI_SM_WAIT_STATE(NCI_RFST_IDLE),
@@ -2246,14 +2725,19 @@ static const TestSmEntry test_nci_sm_dscvr_poll_deact_t4a_badparam1[] = {
 };
 
 static const TestSmEntry test_nci_sm_dscvr_poll_deact_t4a_badparam2[] = {
+    TEST_NCI_SM_EXPECT_CMD(CORE_RESET_CMD),
     TEST_NCI_SM_QUEUE_RSP(CORE_RESET_RSP),
+    TEST_NCI_SM_EXPECT_CMD(CORE_INIT_CMD_V1),
     TEST_NCI_SM_QUEUE_RSP(CORE_INIT_RSP),
-    TEST_NCI_SM_QUEUE_RSP(CORE_GET_CONFIG_RSP),
-    TEST_NCI_SM_QUEUE_RSP(CORE_SET_CONFIG_RSP),
+    TEST_NCI_SM_EXPECT_CMD(CORE_GET_CONFIG_CMD),
+    TEST_NCI_SM_QUEUE_RSP(CORE_GET_CONFIG_RSP_DEFAULT_DURATION),
 
     /* Switch state machine to DISCOVERY state */
+    TEST_NCI_SM_EXPECT_CMD(RF_SET_LISTEN_MODE_ROUTING_CMD_TECHNOLOGY_A_B_F),
     TEST_NCI_SM_QUEUE_RSP(RF_SET_LISTEN_MODE_ROUTING_RSP),
+    TEST_NCI_SM_EXPECT_CMD(RF_DISCOVER_MAP_CMD_A_B_F),
     TEST_NCI_SM_QUEUE_RSP(RF_DISCOVER_MAP_RSP),
+    TEST_NCI_SM_EXPECT_CMD(RF_DISCOVER_CMD_A_B_F),
     TEST_NCI_SM_QUEUE_RSP(RF_DISCOVER_RSP),
     TEST_NCI_SM_SET_STATE(NCI_RFST_DISCOVERY),
     TEST_NCI_SM_WAIT_STATE(NCI_RFST_DISCOVERY),
@@ -2267,28 +2751,33 @@ static const TestSmEntry test_nci_sm_dscvr_poll_deact_t4a_badparam2[] = {
 };
 
 static const TestSmEntry test_nci_sm_discovery_ntf_t2t[] = {
+    TEST_NCI_SM_EXPECT_CMD(CORE_RESET_CMD),
     TEST_NCI_SM_QUEUE_RSP(CORE_RESET_RSP),
+    TEST_NCI_SM_EXPECT_CMD(CORE_INIT_CMD_V1),
     TEST_NCI_SM_QUEUE_RSP(CORE_INIT_RSP_1),
-    TEST_NCI_SM_QUEUE_RSP(CORE_GET_CONFIG_RSP),
-    TEST_NCI_SM_QUEUE_RSP(CORE_SET_CONFIG_RSP),
+    TEST_NCI_SM_EXPECT_CMD(CORE_GET_CONFIG_CMD),
+    TEST_NCI_SM_QUEUE_RSP(CORE_GET_CONFIG_RSP_DEFAULT_DURATION),
 
     /* Switch state machine to DISCOVERY state */
+    TEST_NCI_SM_EXPECT_CMD(RF_SET_LISTEN_MODE_ROUTING_CMD_TECHNOLOGY_A_B_F),
     TEST_NCI_SM_QUEUE_RSP(RF_SET_LISTEN_MODE_ROUTING_RSP),
+    TEST_NCI_SM_EXPECT_CMD(RF_DISCOVER_MAP_CMD_A_B_F),
     TEST_NCI_SM_QUEUE_RSP(RF_DISCOVER_MAP_RSP),
+    TEST_NCI_SM_EXPECT_CMD(RF_DISCOVER_CMD_A_B_F),
     TEST_NCI_SM_QUEUE_RSP(RF_DISCOVER_RSP),
     TEST_NCI_SM_SET_STATE(NCI_RFST_DISCOVERY),
     TEST_NCI_SM_WAIT_STATE(NCI_RFST_DISCOVERY),
 
-    /* Receive 3 discovery notifications (T2T, ISO-DEP, Proprietary) */
-    TEST_NCI_SM_QUEUE_NTF(RF_DISCOVER_NTF_1_ISO_DEP),
+    /* Receive 2 discovery notifications (T2T, Proprietary) */
+    TEST_NCI_SM_QUEUE_NTF(RF_DISCOVER_NTF_1_T2T),
     TEST_NCI_SM_WAIT_STATE(NCI_RFST_W4_ALL_DISCOVERIES),
     TEST_NCI_SM_QUEUE_NTF(CORE_IGNORED_NTF),        /* Ignored */
     TEST_NCI_SM_QUEUE_NTF(RF_IGNORED_NTF),          /* Ignored */
-    TEST_NCI_SM_QUEUE_NTF(RF_DISCOVER_NTF_2_T2T),
-    TEST_NCI_SM_QUEUE_NTF(RF_DISCOVER_NTF_3_PROPRIETARY_LAST),
+    TEST_NCI_SM_QUEUE_NTF(RF_DISCOVER_NTF_2_PROPRIETARY_LAST),
     TEST_NCI_SM_WAIT_STATE(NCI_RFST_W4_HOST_SELECT),
 
     /* Select Type 2 interface */
+    TEST_NCI_SM_EXPECT_CMD(RF_DISCOVER_SELECT_1_T2T_CMD),
     TEST_NCI_SM_QUEUE_RSP(RF_DISCOVER_SELECT_RSP),
     TEST_NCI_SM_QUEUE_NTF(RF_INTF_ACTIVATED_NTF_T2),
     TEST_NCI_SM_WAIT_ACTIVATION(NCI_RF_INTERFACE_FRAME,
@@ -2297,23 +2786,66 @@ static const TestSmEntry test_nci_sm_discovery_ntf_t2t[] = {
     TEST_NCI_SM_END()
 };
 
-static const TestSmEntry test_nci_sm_discovery_ntf_isodep[] = {
+static const TestSmEntry test_nci_sm_discovery_ntf_broken[] = {
+    TEST_NCI_SM_EXPECT_CMD(CORE_RESET_CMD),
     TEST_NCI_SM_QUEUE_RSP(CORE_RESET_RSP),
+    TEST_NCI_SM_EXPECT_CMD(CORE_INIT_CMD_V1),
     TEST_NCI_SM_QUEUE_RSP(CORE_INIT_RSP_1),
-    TEST_NCI_SM_QUEUE_RSP(CORE_GET_CONFIG_RSP),
-    TEST_NCI_SM_QUEUE_RSP(CORE_SET_CONFIG_RSP),
+    TEST_NCI_SM_EXPECT_CMD(CORE_GET_CONFIG_CMD),
+    TEST_NCI_SM_QUEUE_RSP(CORE_GET_CONFIG_RSP_DEFAULT_DURATION),
 
     /* Switch state machine to DISCOVERY state */
+    TEST_NCI_SM_EXPECT_CMD(RF_SET_LISTEN_MODE_ROUTING_CMD_TECHNOLOGY_A_B_F),
     TEST_NCI_SM_QUEUE_RSP(RF_SET_LISTEN_MODE_ROUTING_RSP),
+    TEST_NCI_SM_EXPECT_CMD(RF_DISCOVER_MAP_CMD_A_B_F),
     TEST_NCI_SM_QUEUE_RSP(RF_DISCOVER_MAP_RSP),
+    TEST_NCI_SM_EXPECT_CMD(RF_DISCOVER_CMD_A_B_F),
     TEST_NCI_SM_QUEUE_RSP(RF_DISCOVER_RSP),
     TEST_NCI_SM_SET_STATE(NCI_RFST_DISCOVERY),
     TEST_NCI_SM_WAIT_STATE(NCI_RFST_DISCOVERY),
 
-    /* Receive 2 discovery notifications (ISO-DEP, and Proprietary) */
-    TEST_NCI_SM_QUEUE_NTF(RF_DISCOVER_NTF_1_ISO_DEP),
+    /* Receive 3 discovery notifications (T2T, ISO-DEP, Proprietary) */
+    TEST_NCI_SM_QUEUE_NTF(RF_DISCOVER_NTF_1_T2T),
     TEST_NCI_SM_WAIT_STATE(NCI_RFST_W4_ALL_DISCOVERIES),
     TEST_NCI_SM_QUEUE_NTF(RF_DISCOVER_NTF_2_PROPRIETARY_LAST),
+    TEST_NCI_SM_WAIT_STATE(NCI_RFST_W4_HOST_SELECT),
+
+    /* Select Type 2 interface */
+    TEST_NCI_SM_EXPECT_CMD(RF_DISCOVER_SELECT_1_T2T_CMD),
+    TEST_NCI_SM_QUEUE_RSP(RF_DISCOVER_SELECT_RSP),
+
+    /* Broken notification switches us back to DISCOVERY */
+    TEST_NCI_SM_QUEUE_NTF(RF_INTF_ACTIVATED_NTF_T2_BROKEN1),
+    TEST_NCI_SM_EXPECT_CMD(RF_DEACTIVATE_DISCOVERY_CMD),
+    TEST_NCI_SM_QUEUE_RSP(RF_DEACTIVATE_RSP),
+    TEST_NCI_SM_QUEUE_NTF(RF_DEACTIVATE_NTF_DISCOVERY),
+    TEST_NCI_SM_WAIT_STATE(NCI_RFST_DISCOVERY),
+    TEST_NCI_SM_END()
+};
+
+static const TestSmEntry test_nci_sm_discovery_ntf_isodep[] = {
+    TEST_NCI_SM_EXPECT_CMD(CORE_RESET_CMD),
+    TEST_NCI_SM_QUEUE_RSP(CORE_RESET_RSP),
+    TEST_NCI_SM_EXPECT_CMD(CORE_INIT_CMD_V1),
+    TEST_NCI_SM_QUEUE_RSP(CORE_INIT_RSP_1),
+    TEST_NCI_SM_EXPECT_CMD(CORE_GET_CONFIG_CMD),
+    TEST_NCI_SM_QUEUE_RSP(CORE_GET_CONFIG_RSP_DEFAULT_DURATION),
+
+    /* Switch state machine to DISCOVERY state */
+    TEST_NCI_SM_EXPECT_CMD(RF_SET_LISTEN_MODE_ROUTING_CMD_TECHNOLOGY_A_B_F),
+    TEST_NCI_SM_QUEUE_RSP(RF_SET_LISTEN_MODE_ROUTING_RSP),
+    TEST_NCI_SM_EXPECT_CMD(RF_DISCOVER_MAP_CMD_A_B_F),
+    TEST_NCI_SM_QUEUE_RSP(RF_DISCOVER_MAP_RSP),
+    TEST_NCI_SM_EXPECT_CMD(RF_DISCOVER_CMD_A_B_F),
+    TEST_NCI_SM_QUEUE_RSP(RF_DISCOVER_RSP),
+    TEST_NCI_SM_SET_STATE(NCI_RFST_DISCOVERY),
+    TEST_NCI_SM_WAIT_STATE(NCI_RFST_DISCOVERY),
+
+    /* Receive 2 discovery notifications (ISO-DEP, T2T and Proprietary) */
+    TEST_NCI_SM_QUEUE_NTF(RF_DISCOVER_NTF_1_ISODEP),
+    TEST_NCI_SM_WAIT_STATE(NCI_RFST_W4_ALL_DISCOVERIES),
+    TEST_NCI_SM_QUEUE_NTF(RF_DISCOVER_NTF_2_T2T),
+    TEST_NCI_SM_QUEUE_NTF(RF_DISCOVER_NTF_3_PROPRIETARY_LAST),
     TEST_NCI_SM_WAIT_STATE(NCI_RFST_W4_HOST_SELECT),
 
     /* Make sure these notifications don't change the state */
@@ -2325,10 +2857,11 @@ static const TestSmEntry test_nci_sm_discovery_ntf_isodep[] = {
     TEST_NCI_SM_WAIT_STATE(NCI_RFST_W4_HOST_SELECT),
 
     /* Select ISO-DEP interface */
+    TEST_NCI_SM_EXPECT_CMD(RF_DISCOVER_SELECT_1_ISODEP_CMD),
     TEST_NCI_SM_QUEUE_RSP(RF_DISCOVER_SELECT_RSP),
     TEST_NCI_SM_QUEUE_NTF(CORE_IGNORED_NTF),  /* Ignored */
     TEST_NCI_SM_QUEUE_NTF(RF_IGNORED_NTF),    /* Ignored */
-    TEST_NCI_SM_QUEUE_NTF(RF_INTF_ACTIVATED_NTF_ISO_DEP),
+    TEST_NCI_SM_QUEUE_NTF(RF_INTF_ACTIVATED_NTF_ISODEP),
     TEST_NCI_SM_WAIT_ACTIVATION(NCI_RF_INTERFACE_ISO_DEP,
         NCI_PROTOCOL_ISO_DEP, NCI_MODE_PASSIVE_POLL_A),
     TEST_NCI_SM_WAIT_STATE(NCI_RFST_POLL_ACTIVE),
@@ -2336,6 +2869,7 @@ static const TestSmEntry test_nci_sm_discovery_ntf_isodep[] = {
     /* Try to deactivate to DISCOVERY */
     TEST_NCI_SM_QUEUE_NTF(CORE_INTERFACE_TIMEOUT_ERROR_NTF),
     TEST_NCI_SM_SET_STATE(NCI_RFST_DISCOVERY),
+    TEST_NCI_SM_EXPECT_CMD(RF_DEACTIVATE_DISCOVERY_CMD),
     TEST_NCI_SM_QUEUE_RSP(RF_DEACTIVATE_RSP),
 
     /* But end up in IDLE */
@@ -2345,43 +2879,59 @@ static const TestSmEntry test_nci_sm_discovery_ntf_isodep[] = {
 };
 
 static const TestSmEntry test_nci_sm_discovery_ntf_isodep_fail[] = {
+    TEST_NCI_SM_EXPECT_CMD(CORE_RESET_CMD),
     TEST_NCI_SM_QUEUE_RSP(CORE_RESET_RSP),
+    TEST_NCI_SM_EXPECT_CMD(CORE_INIT_CMD_V1),
     TEST_NCI_SM_QUEUE_RSP(CORE_INIT_RSP_1),
-    TEST_NCI_SM_QUEUE_RSP(CORE_GET_CONFIG_RSP),
-    TEST_NCI_SM_QUEUE_RSP(CORE_SET_CONFIG_RSP),
+    TEST_NCI_SM_EXPECT_CMD(CORE_GET_CONFIG_CMD),
+    TEST_NCI_SM_QUEUE_RSP(CORE_GET_CONFIG_RSP_DEFAULT_DURATION),
 
     /* Switch state machine to DISCOVERY state */
+    TEST_NCI_SM_EXPECT_CMD(RF_SET_LISTEN_MODE_ROUTING_CMD_TECHNOLOGY_A_B_F),
     TEST_NCI_SM_QUEUE_RSP(RF_SET_LISTEN_MODE_ROUTING_RSP),
+    TEST_NCI_SM_EXPECT_CMD(RF_DISCOVER_MAP_CMD_A_B_F),
     TEST_NCI_SM_QUEUE_RSP(RF_DISCOVER_MAP_RSP),
+    TEST_NCI_SM_EXPECT_CMD(RF_DISCOVER_CMD_A_B_F),
     TEST_NCI_SM_QUEUE_RSP(RF_DISCOVER_RSP),
     TEST_NCI_SM_SET_STATE(NCI_RFST_DISCOVERY),
     TEST_NCI_SM_WAIT_STATE(NCI_RFST_DISCOVERY),
 
     /* Receive 2 discovery notifications (ISO-DEP, and Proprietary) */
-    TEST_NCI_SM_QUEUE_NTF(RF_DISCOVER_NTF_1_ISO_DEP),
+    TEST_NCI_SM_QUEUE_NTF(RF_DISCOVER_NTF_1_ISODEP),
     TEST_NCI_SM_WAIT_STATE(NCI_RFST_W4_ALL_DISCOVERIES),
     TEST_NCI_SM_QUEUE_NTF(RF_DISCOVER_NTF_2_PROPRIETARY_LAST),
+    TEST_NCI_SM_EXPECT_CMD(RF_DISCOVER_SELECT_1_ISODEP_CMD),
     TEST_NCI_SM_WAIT_STATE(NCI_RFST_W4_HOST_SELECT),
+    TEST_NCI_SM_SYNC(),
 
     /* Activation failure sends us back to DISCOVERY state */
     TEST_NCI_SM_QUEUE_NTF(CORE_GENERIC_TARGET_ACTIVATION_FAILED_ERROR_NTF),
+    TEST_NCI_SM_EXPECT_CMD(RF_DEACTIVATE_IDLE_CMD),
     TEST_NCI_SM_QUEUE_RSP(RF_DEACTIVATE_RSP),
+    TEST_NCI_SM_EXPECT_CMD(RF_SET_LISTEN_MODE_ROUTING_CMD_TECHNOLOGY_A_B_F),
     TEST_NCI_SM_QUEUE_RSP(RF_SET_LISTEN_MODE_ROUTING_RSP),
+    TEST_NCI_SM_EXPECT_CMD(RF_DISCOVER_MAP_CMD_A_B_F),
     TEST_NCI_SM_QUEUE_RSP(RF_DISCOVER_MAP_RSP),
+    TEST_NCI_SM_EXPECT_CMD(RF_DISCOVER_CMD_A_B_F),
     TEST_NCI_SM_QUEUE_RSP(RF_DISCOVER_RSP),
     TEST_NCI_SM_WAIT_STATE(NCI_RFST_DISCOVERY),
     TEST_NCI_SM_END()
 };
 
 static const TestSmEntry test_nci_sm_discovery_ntf_noselect[] = {
+    TEST_NCI_SM_EXPECT_CMD(CORE_RESET_CMD),
     TEST_NCI_SM_QUEUE_RSP(CORE_RESET_RSP),
+    TEST_NCI_SM_EXPECT_CMD(CORE_INIT_CMD_V1),
     TEST_NCI_SM_QUEUE_RSP(CORE_INIT_RSP_1),
-    TEST_NCI_SM_QUEUE_RSP(CORE_GET_CONFIG_RSP),
-    TEST_NCI_SM_QUEUE_RSP(CORE_SET_CONFIG_RSP),
+    TEST_NCI_SM_EXPECT_CMD(CORE_GET_CONFIG_CMD),
+    TEST_NCI_SM_QUEUE_RSP(CORE_GET_CONFIG_RSP_DEFAULT_DURATION),
 
     /* Switch state machine to DISCOVERY state */
+    TEST_NCI_SM_EXPECT_CMD(RF_SET_LISTEN_MODE_ROUTING_CMD_TECHNOLOGY_A_B_F),
     TEST_NCI_SM_QUEUE_RSP(RF_SET_LISTEN_MODE_ROUTING_RSP),
+    TEST_NCI_SM_EXPECT_CMD(RF_DISCOVER_MAP_CMD_A_B_F),
     TEST_NCI_SM_QUEUE_RSP(RF_DISCOVER_MAP_RSP),
+    TEST_NCI_SM_EXPECT_CMD(RF_DISCOVER_CMD_A_B_F),
     TEST_NCI_SM_QUEUE_RSP(RF_DISCOVER_RSP),
     TEST_NCI_SM_SET_STATE(NCI_RFST_DISCOVERY),
     TEST_NCI_SM_WAIT_STATE(NCI_RFST_DISCOVERY),
@@ -2393,11 +2943,15 @@ static const TestSmEntry test_nci_sm_discovery_ntf_noselect[] = {
     TEST_NCI_SM_WAIT_STATE(NCI_RFST_W4_HOST_SELECT),
 
     /* State machine will deactivate to DISCOVERY via IDLE */
+    TEST_NCI_SM_EXPECT_CMD(RF_DEACTIVATE_IDLE_CMD),
     TEST_NCI_SM_QUEUE_RSP(RF_DEACTIVATE_RSP),
     TEST_NCI_SM_WAIT_STATE(NCI_RFST_IDLE),
+    TEST_NCI_SM_EXPECT_CMD(RF_SET_LISTEN_MODE_ROUTING_CMD_TECHNOLOGY_A_B_F),
     TEST_NCI_SM_ASSERT_STATES(NCI_RFST_IDLE, NCI_RFST_DISCOVERY),
     TEST_NCI_SM_QUEUE_RSP(RF_SET_LISTEN_MODE_ROUTING_RSP),
+    TEST_NCI_SM_EXPECT_CMD(RF_DISCOVER_MAP_CMD_A_B_F),
     TEST_NCI_SM_QUEUE_RSP(RF_DISCOVER_MAP_RSP),
+    TEST_NCI_SM_EXPECT_CMD(RF_DISCOVER_CMD_A_B_F),
     TEST_NCI_SM_QUEUE_RSP(RF_DISCOVER_RSP),
     TEST_NCI_SM_WAIT_STATE(NCI_RFST_DISCOVERY),
     TEST_NCI_SM_END()
@@ -2405,20 +2959,25 @@ static const TestSmEntry test_nci_sm_discovery_ntf_noselect[] = {
 
 static const TestSmEntry test_nci_sm_nfc_dep_listen_disappear[] = {
     TEST_NCI_SM_SET_OP_MODE(NFC_OP_MODE_PEER|NFC_OP_MODE_LISTEN),
+    TEST_NCI_SM_EXPECT_CMD(CORE_RESET_CMD),
     TEST_NCI_SM_QUEUE_RSP(CORE_RESET_RSP),
+    TEST_NCI_SM_EXPECT_CMD(CORE_INIT_CMD_V1),
     TEST_NCI_SM_QUEUE_RSP(CORE_INIT_RSP_1),
-    TEST_NCI_SM_QUEUE_RSP(CORE_GET_CONFIG_RSP),
-    TEST_NCI_SM_QUEUE_RSP(CORE_SET_CONFIG_RSP),
+    TEST_NCI_SM_EXPECT_CMD(CORE_GET_CONFIG_CMD),
+    TEST_NCI_SM_QUEUE_RSP(CORE_GET_CONFIG_RSP_DEFAULT_DURATION),
 
     /* Switch state machine to DISCOVERY state */
+    TEST_NCI_SM_EXPECT_CMD(RF_SET_LISTEN_MODE_ROUTING_CMD_TECHNOLOGY_A_B_F),
     TEST_NCI_SM_QUEUE_RSP(RF_SET_LISTEN_MODE_ROUTING_RSP),
+    TEST_NCI_SM_EXPECT_CMD(RF_DISCOVER_MAP_CMD_NFCDEP),
     TEST_NCI_SM_QUEUE_RSP(RF_DISCOVER_MAP_RSP),
+    TEST_NCI_SM_EXPECT_CMD(RF_DISCOVER_CMD_NFCDEP),
     TEST_NCI_SM_QUEUE_RSP(RF_DISCOVER_RSP),
     TEST_NCI_SM_SET_STATE(NCI_RFST_DISCOVERY),
     TEST_NCI_SM_WAIT_STATE(NCI_RFST_DISCOVERY),
 
     /* NFC-DEP peer appears and disappears */
-    TEST_NCI_SM_QUEUE_NTF(RF_INTF_ACTIVATED_NTF_NFC_DEP_LISTEN_A),
+    TEST_NCI_SM_QUEUE_NTF(RF_INTF_ACTIVATED_NTF_NFCDEP_LISTEN_A),
     TEST_NCI_SM_WAIT_ACTIVATION(NCI_RF_INTERFACE_NFC_DEP,
         NCI_PROTOCOL_NFC_DEP, NCI_MODE_ACTIVE_LISTEN_A),
     TEST_NCI_SM_WAIT_STATE(NCI_RFST_LISTEN_ACTIVE),
@@ -2429,20 +2988,25 @@ static const TestSmEntry test_nci_sm_nfc_dep_listen_disappear[] = {
 
 static const TestSmEntry test_nci_sm_nfc_dep_listen_timeout[] = {
     TEST_NCI_SM_SET_OP_MODE(NFC_OP_MODE_PEER|NFC_OP_MODE_LISTEN),
+    TEST_NCI_SM_EXPECT_CMD(CORE_RESET_CMD),
     TEST_NCI_SM_QUEUE_RSP(CORE_RESET_RSP),
+    TEST_NCI_SM_EXPECT_CMD(CORE_INIT_CMD_V1),
     TEST_NCI_SM_QUEUE_RSP(CORE_INIT_RSP_1),
-    TEST_NCI_SM_QUEUE_RSP(CORE_GET_CONFIG_RSP),
-    TEST_NCI_SM_QUEUE_RSP(CORE_SET_CONFIG_RSP),
+    TEST_NCI_SM_EXPECT_CMD(CORE_GET_CONFIG_CMD),
+    TEST_NCI_SM_QUEUE_RSP(CORE_GET_CONFIG_RSP_DEFAULT_DURATION),
 
     /* Switch state machine to DISCOVERY state */
+    TEST_NCI_SM_EXPECT_CMD(RF_SET_LISTEN_MODE_ROUTING_CMD_TECHNOLOGY_A_B_F),
     TEST_NCI_SM_QUEUE_RSP(RF_SET_LISTEN_MODE_ROUTING_RSP),
+    TEST_NCI_SM_EXPECT_CMD(RF_DISCOVER_MAP_CMD_NFCDEP),
     TEST_NCI_SM_QUEUE_RSP(RF_DISCOVER_MAP_RSP),
+    TEST_NCI_SM_EXPECT_CMD(RF_DISCOVER_CMD_NFCDEP),
     TEST_NCI_SM_QUEUE_RSP(RF_DISCOVER_RSP),
     TEST_NCI_SM_SET_STATE(NCI_RFST_DISCOVERY),
     TEST_NCI_SM_WAIT_STATE(NCI_RFST_DISCOVERY),
 
     /* NFC-DEP peer appears */
-    TEST_NCI_SM_QUEUE_NTF(RF_INTF_ACTIVATED_NTF_NFC_DEP_LISTEN_A),
+    TEST_NCI_SM_QUEUE_NTF(RF_INTF_ACTIVATED_NTF_NFCDEP_LISTEN_A),
     TEST_NCI_SM_WAIT_ACTIVATION(NCI_RF_INTERFACE_NFC_DEP,
         NCI_PROTOCOL_NFC_DEP, NCI_MODE_ACTIVE_LISTEN_A),
     TEST_NCI_SM_WAIT_STATE(NCI_RFST_LISTEN_ACTIVE),
@@ -2457,36 +3021,40 @@ static const TestSmEntry test_nci_sm_nfc_dep_listen_timeout[] = {
 
     /* Error notification moves state machine back to DISCOVERY */
     TEST_NCI_SM_QUEUE_NTF(CORE_INTERFACE_TIMEOUT_ERROR_NTF),
+    TEST_NCI_SM_EXPECT_CMD(RF_DEACTIVATE_DISCOVERY_CMD),
     TEST_NCI_SM_QUEUE_RSP(RF_DEACTIVATE_RSP),
     TEST_NCI_SM_QUEUE_NTF(RF_DEACTIVATE_NTF_DISCOVERY),
     TEST_NCI_SM_WAIT_STATE(NCI_RFST_DISCOVERY),
 
     /* The same with other errors */
-    TEST_NCI_SM_QUEUE_NTF(RF_INTF_ACTIVATED_NTF_NFC_DEP_LISTEN_A),
+    TEST_NCI_SM_QUEUE_NTF(RF_INTF_ACTIVATED_NTF_NFCDEP_LISTEN_A),
     TEST_NCI_SM_WAIT_ACTIVATION(NCI_RF_INTERFACE_NFC_DEP,
         NCI_PROTOCOL_NFC_DEP, NCI_MODE_ACTIVE_LISTEN_A),
     TEST_NCI_SM_WAIT_STATE(NCI_RFST_LISTEN_ACTIVE),
     TEST_NCI_SM_QUEUE_NTF(CORE_INTERFACE_PROTOCOL_ERROR_NTF),
+    TEST_NCI_SM_EXPECT_CMD(RF_DEACTIVATE_DISCOVERY_CMD),
     TEST_NCI_SM_QUEUE_RSP(RF_DEACTIVATE_RSP),
     TEST_NCI_SM_WAIT_STATE(NCI_RFST_LISTEN_ACTIVE),
     TEST_NCI_SM_ASSERT_STATES(NCI_RFST_LISTEN_ACTIVE, NCI_RFST_DISCOVERY),
     TEST_NCI_SM_QUEUE_NTF(RF_DEACTIVATE_NTF_DISCOVERY),
     TEST_NCI_SM_WAIT_STATE(NCI_RFST_DISCOVERY),
 
-    TEST_NCI_SM_QUEUE_NTF(RF_INTF_ACTIVATED_NTF_NFC_DEP_LISTEN_A),
+    TEST_NCI_SM_QUEUE_NTF(RF_INTF_ACTIVATED_NTF_NFCDEP_LISTEN_A),
     TEST_NCI_SM_WAIT_ACTIVATION(NCI_RF_INTERFACE_NFC_DEP,
         NCI_PROTOCOL_NFC_DEP, NCI_MODE_ACTIVE_LISTEN_A),
     TEST_NCI_SM_WAIT_STATE(NCI_RFST_LISTEN_ACTIVE),
     TEST_NCI_SM_QUEUE_NTF(CORE_INTERFACE_TRANSMISSION_ERROR_NTF),
+    TEST_NCI_SM_EXPECT_CMD(RF_DEACTIVATE_DISCOVERY_CMD),
     TEST_NCI_SM_QUEUE_RSP(RF_DEACTIVATE_RSP),
     TEST_NCI_SM_QUEUE_NTF(RF_DEACTIVATE_NTF_DISCOVERY),
     TEST_NCI_SM_WAIT_STATE(NCI_RFST_DISCOVERY),
 
-    TEST_NCI_SM_QUEUE_NTF(RF_INTF_ACTIVATED_NTF_NFC_DEP_LISTEN_A),
+    TEST_NCI_SM_QUEUE_NTF(RF_INTF_ACTIVATED_NTF_NFCDEP_LISTEN_A),
     TEST_NCI_SM_WAIT_ACTIVATION(NCI_RF_INTERFACE_NFC_DEP,
         NCI_PROTOCOL_NFC_DEP, NCI_MODE_ACTIVE_LISTEN_A),
     TEST_NCI_SM_WAIT_STATE(NCI_RFST_LISTEN_ACTIVE),
     TEST_NCI_SM_QUEUE_NTF(CORE_INTERFACE_SYNTAX_ERROR_NTF),
+    TEST_NCI_SM_EXPECT_CMD(RF_DEACTIVATE_DISCOVERY_CMD),
     TEST_NCI_SM_QUEUE_RSP(RF_DEACTIVATE_RSP),
     TEST_NCI_SM_QUEUE_NTF(RF_DEACTIVATE_NTF_DISCOVERY),
     TEST_NCI_SM_WAIT_STATE(NCI_RFST_DISCOVERY),
@@ -2496,20 +3064,25 @@ static const TestSmEntry test_nci_sm_nfc_dep_listen_timeout[] = {
 
 static const TestSmEntry test_nci_sm_nfc_dep_listen_sleep[] = {
     TEST_NCI_SM_SET_OP_MODE(NFC_OP_MODE_PEER|NFC_OP_MODE_LISTEN),
+    TEST_NCI_SM_EXPECT_CMD(CORE_RESET_CMD),
+    TEST_NCI_SM_EXPECT_CMD(CORE_INIT_CMD_V1),
     TEST_NCI_SM_QUEUE_RSP(CORE_RESET_RSP),
     TEST_NCI_SM_QUEUE_RSP(CORE_INIT_RSP_1),
-    TEST_NCI_SM_QUEUE_RSP(CORE_GET_CONFIG_RSP),
-    TEST_NCI_SM_QUEUE_RSP(CORE_SET_CONFIG_RSP),
+    TEST_NCI_SM_EXPECT_CMD(CORE_GET_CONFIG_CMD),
+    TEST_NCI_SM_QUEUE_RSP(CORE_GET_CONFIG_RSP_DEFAULT_DURATION),
 
     /* Switch state machine to DISCOVERY state */
+    TEST_NCI_SM_EXPECT_CMD(RF_SET_LISTEN_MODE_ROUTING_CMD_TECHNOLOGY_A_B_F),
     TEST_NCI_SM_QUEUE_RSP(RF_SET_LISTEN_MODE_ROUTING_RSP),
+    TEST_NCI_SM_EXPECT_CMD(RF_DISCOVER_MAP_CMD_NFCDEP),
     TEST_NCI_SM_QUEUE_RSP(RF_DISCOVER_MAP_RSP),
+    TEST_NCI_SM_EXPECT_CMD(RF_DISCOVER_CMD_NFCDEP),
     TEST_NCI_SM_QUEUE_RSP(RF_DISCOVER_RSP),
     TEST_NCI_SM_SET_STATE(NCI_RFST_DISCOVERY),
     TEST_NCI_SM_WAIT_STATE(NCI_RFST_DISCOVERY),
 
     /* NFC-DEP peer appears */
-    TEST_NCI_SM_QUEUE_NTF(RF_INTF_ACTIVATED_NTF_NFC_DEP_LISTEN_A),
+    TEST_NCI_SM_QUEUE_NTF(RF_INTF_ACTIVATED_NTF_NFCDEP_LISTEN_A),
     TEST_NCI_SM_WAIT_ACTIVATION(NCI_RF_INTERFACE_NFC_DEP,
         NCI_PROTOCOL_NFC_DEP, NCI_MODE_ACTIVE_LISTEN_A),
     TEST_NCI_SM_WAIT_STATE(NCI_RFST_LISTEN_ACTIVE),
@@ -2522,7 +3095,7 @@ static const TestSmEntry test_nci_sm_nfc_dep_listen_sleep[] = {
     TEST_NCI_SM_ASSERT_STATE(NCI_RFST_LISTEN_SLEEP),
 
     /* NFC-DEP re-appears */
-    TEST_NCI_SM_QUEUE_NTF(RF_INTF_ACTIVATED_NTF_NFC_DEP_LISTEN_A),
+    TEST_NCI_SM_QUEUE_NTF(RF_INTF_ACTIVATED_NTF_NFCDEP_LISTEN_A),
     TEST_NCI_SM_WAIT_ACTIVATION(NCI_RF_INTERFACE_NFC_DEP,
         NCI_PROTOCOL_NFC_DEP, NCI_MODE_ACTIVE_LISTEN_A),
     TEST_NCI_SM_WAIT_STATE(NCI_RFST_LISTEN_ACTIVE),
@@ -2537,18 +3110,23 @@ static const TestSmEntry test_nci_sm_nfc_dep_listen_sleep[] = {
     TEST_NCI_SM_END()
 };
 
-static const TestSmEntry test_nci_sm_iso_dep_ce[] = {
+static const TestSmEntry test_nci_sm_iso_dep_ce_tech_routing[] = {
     TEST_NCI_SM_SET_OP_MODE(NFC_OP_MODE_CE|NFC_OP_MODE_LISTEN),
+    TEST_NCI_SM_EXPECT_CMD(CORE_RESET_CMD),
     TEST_NCI_SM_QUEUE_RSP(CORE_RESET_V2_RSP),
     TEST_NCI_SM_QUEUE_NTF(CORE_RESET_V2_NTF),
+    TEST_NCI_SM_EXPECT_CMD(CORE_INIT_CMD_V2),
     TEST_NCI_SM_QUEUE_RSP(CORE_INIT_V2_RSP),
-    TEST_NCI_SM_QUEUE_RSP(CORE_GET_CONFIG_RSP),
-    TEST_NCI_SM_QUEUE_RSP(CORE_SET_CONFIG_RSP),
+    TEST_NCI_SM_EXPECT_CMD(CORE_GET_CONFIG_CMD),
+    TEST_NCI_SM_QUEUE_RSP(CORE_GET_CONFIG_RSP_DEFAULT_DURATION),
     TEST_NCI_SM_WAIT_STATE(NCI_RFST_IDLE),
 
     /* Switch state machine to DISCOVERY state */
+    TEST_NCI_SM_EXPECT_CMD(RF_SET_LISTEN_MODE_ROUTING_CMD_TECHNOLOGY_A_B_F),
     TEST_NCI_SM_QUEUE_RSP(RF_SET_LISTEN_MODE_ROUTING_RSP),
+    TEST_NCI_SM_EXPECT_CMD(RF_DISCOVER_MAP_CMD_LISTEN_ISODEP),
     TEST_NCI_SM_QUEUE_RSP(RF_DISCOVER_MAP_RSP),
+    TEST_NCI_SM_EXPECT_CMD(RF_DISCOVER_CMD_A_B_LISTEN),
     TEST_NCI_SM_QUEUE_RSP(RF_DISCOVER_RSP),
     TEST_NCI_SM_SET_STATE(NCI_RFST_DISCOVERY),
     TEST_NCI_SM_WAIT_STATE(NCI_RFST_DISCOVERY),
@@ -2561,6 +3139,43 @@ static const TestSmEntry test_nci_sm_iso_dep_ce[] = {
 
     /* Error moves state machine back to DISCOVERY */
     TEST_NCI_SM_QUEUE_NTF(CORE_INTERFACE_TIMEOUT_ERROR_NTF),
+    TEST_NCI_SM_EXPECT_CMD(RF_DEACTIVATE_DISCOVERY_CMD),
+    TEST_NCI_SM_QUEUE_RSP(RF_DEACTIVATE_RSP),
+    TEST_NCI_SM_QUEUE_NTF(RF_DEACTIVATE_NTF_DISCOVERY),
+    TEST_NCI_SM_WAIT_STATE(NCI_RFST_DISCOVERY),
+    TEST_NCI_SM_END()
+};
+
+static const TestSmEntry test_nci_sm_iso_dep_ce_prot_routing[] = {
+    TEST_NCI_SM_SET_OP_MODE(NFC_OP_MODE_CE|NFC_OP_MODE_LISTEN),
+    TEST_NCI_SM_EXPECT_CMD(CORE_RESET_CMD),
+    TEST_NCI_SM_QUEUE_RSP(CORE_RESET_V2_RSP),
+    TEST_NCI_SM_QUEUE_NTF(CORE_RESET_V2_NTF),
+    TEST_NCI_SM_EXPECT_CMD(CORE_INIT_CMD_V2),
+    TEST_NCI_SM_QUEUE_RSP(CORE_INIT_V2_RSP_NO_TECHNOLOGY_ROUTING),
+    TEST_NCI_SM_EXPECT_CMD(CORE_GET_CONFIG_CMD),
+    TEST_NCI_SM_QUEUE_RSP(CORE_GET_CONFIG_RSP_DEFAULT_DURATION),
+    TEST_NCI_SM_WAIT_STATE(NCI_RFST_IDLE),
+
+    /* Switch state machine to DISCOVERY state */
+    TEST_NCI_SM_EXPECT_CMD(RF_SET_LISTEN_MODE_ROUTING_CMD_PROTOCOL_ISODEP),
+    TEST_NCI_SM_QUEUE_RSP(RF_SET_LISTEN_MODE_ROUTING_RSP),
+    TEST_NCI_SM_EXPECT_CMD(RF_DISCOVER_MAP_CMD_LISTEN_ISODEP),
+    TEST_NCI_SM_QUEUE_RSP(RF_DISCOVER_MAP_RSP),
+    TEST_NCI_SM_EXPECT_CMD(RF_DISCOVER_CMD_A_B_LISTEN),
+    TEST_NCI_SM_QUEUE_RSP(RF_DISCOVER_RSP),
+    TEST_NCI_SM_SET_STATE(NCI_RFST_DISCOVERY),
+    TEST_NCI_SM_WAIT_STATE(NCI_RFST_DISCOVERY),
+
+    /* NFC-A/ISO-DEP Listen Mode activation */
+    TEST_NCI_SM_QUEUE_NTF(RF_INTF_ACTIVATED_NTF_CE_A),
+    TEST_NCI_SM_WAIT_ACTIVATION(NCI_RF_INTERFACE_ISO_DEP,
+        NCI_PROTOCOL_ISO_DEP, NCI_MODE_PASSIVE_LISTEN_A),
+    TEST_NCI_SM_WAIT_STATE(NCI_RFST_LISTEN_ACTIVE),
+
+    /* Error moves state machine back to DISCOVERY */
+    TEST_NCI_SM_QUEUE_NTF(CORE_INTERFACE_TIMEOUT_ERROR_NTF),
+    TEST_NCI_SM_EXPECT_CMD(RF_DEACTIVATE_DISCOVERY_CMD),
     TEST_NCI_SM_QUEUE_RSP(RF_DEACTIVATE_RSP),
     TEST_NCI_SM_QUEUE_NTF(RF_DEACTIVATE_NTF_DISCOVERY),
     TEST_NCI_SM_WAIT_STATE(NCI_RFST_DISCOVERY),
@@ -2575,12 +3190,14 @@ static const TestNciSmData nci_sm_tests[] = {
     { "init-ok-broken-duration2", test_nci_sm_init_ok_broken_duration2 },
     { "init-ok-broken-duration3", test_nci_sm_init_ok_broken_duration3 },
     { "init-timeout", test_nci_sm_init_timeout },
+    { "reset-timeout", test_nci_sm_reset_timeout },
     { "get-config-timeout", test_nci_sm_get_config_timeout },
     { "set-config-timeout", test_nci_sm_set_config_timeout },
     { "init-v2", test_nci_sm_init_v2 },
     { "init-v2-error", test_nci_sm_init_v2_error },
     { "init-v2-broken1", test_nci_sm_init_v2_broken1 },
     { "init-v2-broken2", test_nci_sm_init_v2_broken2 },
+    { "init-v2-timeout", test_nci_sm_init_v2_timeout },
     { "reset-failed", test_nci_sm_reset_failed },
     { "reset-broken", test_nci_sm_reset_broken },
     { "init-broken", test_nci_sm_init_broken },
@@ -2603,6 +3220,7 @@ static const TestNciSmData nci_sm_tests[] = {
     { "discovery-idle-discovery2", test_nci_sm_discovery_idle_discovery2 },
     { "discovery-idle-failed", test_nci_sm_discovery_idle_failed },
     { "discovery-idle-broken", test_nci_sm_discovery_idle_broken },
+    { "discovery-idle-timeout", test_nci_sm_discovery_idle_timeout },
     { "discovery-poll-idle", test_nci_sm_discovery_poll_idle },
     { "discovery-poll-idle-failed", test_nci_sm_discovery_poll_idle_failed },
     { "discovery-poll-idle-broken1", test_nci_sm_discovery_poll_idle_broken1 },
@@ -2623,13 +3241,15 @@ static const TestNciSmData nci_sm_tests[] = {
     { "discovery-poll-deactivate-t4a-bad-act-param2",
        test_nci_sm_dscvr_poll_deact_t4a_badparam2 },
     { "discovery-ntf-t2t", test_nci_sm_discovery_ntf_t2t },
+    { "discovery-ntf-broken", test_nci_sm_discovery_ntf_broken },
     { "discovery-ntf-isodep", test_nci_sm_discovery_ntf_isodep },
     { "discovery-ntf-isodep-fail", test_nci_sm_discovery_ntf_isodep_fail },
     { "discovery-ntf-noselect", test_nci_sm_discovery_ntf_noselect },
     { "nfcdep-listen-disappear", test_nci_sm_nfc_dep_listen_disappear },
     { "nfcdep-listen-timeout", test_nci_sm_nfc_dep_listen_timeout },
     { "nfcdep-listen-sleep", test_nci_sm_nfc_dep_listen_sleep },
-    { "ce-poll_a", test_nci_sm_iso_dep_ce }
+    { "ce-poll_a_tech_routing", test_nci_sm_iso_dep_ce_tech_routing },
+    { "ce-poll_a_prot_routing", test_nci_sm_iso_dep_ce_prot_routing }
 };
 
 /*==========================================================================*


### PR DESCRIPTION
Rolled back run time detection of NFC-F support - it turned out to be unreliable. Bit `b1` of `LF_PROTOCOL_TYPE` is writeable, and therefore doesn't reflect the actual capability of the NFC chip.

Instead, introducing `/etc/libncicore.conf` file, where one can specify which technologies are supported by the NFC chip, e.g.
```ini
[Configuration]
Technologies = A,B
```
By default, all technologies (A, B, F) are assumed to be supported.

Unit tests have been strengthened. In addition to simulating responses and notifications, they now validate NCI commands which are being produced by the library.