### PR TITLE
Allow to configure LA_NFCID1 parameter

### DIFF
--- a/include/nci_core.h
+++ b/include/nci_core.h
@@ -51,8 +51,9 @@ typedef struct nci_core {
 /* NCI parameters */
 
 typedef enum nci_core_param_key {
-    NCI_CORE_PARAM_LLC_VERSION,  /* uint8, default is 0x11 (v1.1) */
-    NCI_CORE_PARAM_LLC_WKS,      /* uint16, default is 0x0003 (SDP-only) */
+    NCI_CORE_PARAM_LLC_VERSION, /* uint8, default is 0x11 (v1.1) */
+    NCI_CORE_PARAM_LLC_WKS,     /* uint16, default is 0x0003 (SDP-only) */
+    NCI_CORE_PARAM_LA_NFCID1,   /* nfcid1, default is dynamic (Since 1.1.22) */
     NCI_CORE_PARAM_COUNT
 } NCI_CORE_PARAM; /* Since 1.1.18 */
 
@@ -60,6 +61,7 @@ typedef union nci_core_param_value {
     guint8 uint8;
     guint16 uint16;
     guint32 uint32;
+    NciNfcid1 nfcid1; /* Since 1.1.22 */
 } NciCoreParamValue; /* Since 1.1.18 */
 
 typedef struct nci_core_param {

--- a/include/nci_types.h
+++ b/include/nci_types.h
@@ -265,6 +265,12 @@ typedef struct nci_discovery_ntf {
     gboolean last;
 } NciDiscoveryNtf;
 
+/* NFCID1 can be 4, 7, or 10 bytes long. */
+typedef struct nci_nfcid {
+    guint8 len;
+    guint8 bytes[10];
+} NciNfcid1; /* Since 1.1.22 */
+
 /* This is essentially NCI_MODE as a bitmask */
 
 typedef enum nci_tech {

--- a/rpm/libncicore.spec
+++ b/rpm/libncicore.spec
@@ -7,7 +7,7 @@ License: BSD
 URL: https://github.com/mer-hybris/libncicore
 Source: %{name}-%{version}.tar.bz2
 
-%define libglibutil_version 1.0.52
+%define libglibutil_version 1.0.71
 %define glib_version 2.32
 
 BuildRequires: pkgconfig

--- a/src/nci_sm.h
+++ b/src/nci_sm.h
@@ -271,6 +271,7 @@ struct nci_sm {
     NCI_OP_MODE op_mode;
     guint8 llc_version;
     guint16 llc_wks;
+    NciNfcid1 la_nfcid1; /* NFCID1 in Listen A mode */
 };
 
 typedef
@@ -329,6 +330,12 @@ NCI_TECH
 nci_sm_set_tech(
     NciSm* sm,
     NCI_TECH tech)
+    NCI_INTERNAL;
+
+void
+nci_sm_set_la_nfcid1(
+    NciSm* sm,
+    const NciNfcid1* nfcid1)
     NCI_INTERNAL;
 
 void

--- a/src/nci_util_p.h
+++ b/src/nci_util_p.h
@@ -1,6 +1,6 @@
 /*
+ * Copyright (C) 2019-2023 Slava Monich <slava@monich.com>
  * Copyright (C) 2019-2021 Jolla Ltd.
- * Copyright (C) 2019-2021 Slava Monich <slava.monich@jolla.com>
  * Copyright (C) 2020 Open Mobile Platform LLC.
  *
  * You may use this file under the terms of BSD license as follows:
@@ -38,6 +38,17 @@
 #include "nci_types_p.h"
 
 gboolean
+nci_nfcid1_dynamic(
+    const NciNfcid1* id)
+    NCI_INTERNAL;
+
+gboolean
+nci_nfcid1_equal(
+    const NciNfcid1* id1,
+    const NciNfcid1* id2)
+    NCI_INTERNAL;
+
+gboolean
 nci_listen_mode(
     NCI_MODE mode)
     NCI_INTERNAL;
@@ -48,6 +59,14 @@ nci_parse_config_param_uint(
     const GUtilData* params,
     guint8 id,
     guint* value)
+    NCI_INTERNAL;
+
+gboolean
+nci_parse_config_param_nfcid1(
+    guint nparams,
+    const GUtilData* params,
+    guint8 id,
+    NciNfcid1* value)
     NCI_INTERNAL;
 
 const NciModeParam*

--- a/unit/nci_core/test_nci_core.c
+++ b/unit/nci_core/test_nci_core.c
@@ -50,6 +50,7 @@ static TestOpt test_opt;
 #define TMP_DIR_TEMPLATE "test-nci-core-XXXXXX"
 #define CONFIG_SECTION "[Configuration]"
 #define CONFIG_ENTRY_TECHNOLOGIES "Technologies"
+#define CONFIG_ENTRY_LA_NFCID1 "LA_NFCID1"
 
 static const guint8 CORE_RESET_CMD[] = {
     0x20, 0x00, 0x01, 0x00
@@ -188,34 +189,45 @@ static const guint8 CORE_SET_CONFIG_RSP_ERROR[] = {
     0x40, 0x02, 0x02, NCI_STATUS_REJECTED, 0x00
 };
 static const guint8 CORE_GET_CONFIG_CMD_DISCOVERY[] = {
-    0x20, 0x03, 0x03, 0x02, 0x32, 0x50 /* LA_SEL_INFO, LF_PROTOCOL_TYPE */
+    /* LA_NFCID1, LA_SEL_INFO, LF_PROTOCOL_TYPE */
+    0x20, 0x03, 0x04, 0x03, 0x33, 0x32, 0x50
 };
 static const guint8 CORE_GET_CONFIG_RSP_DISCOVERY_INVALID_PARAM[] = {
     0x40, 0x03, 0x06, NCI_STATUS_INVALID_PARAM, 0x02,
     0x32, 0x00, 0x50, 0x00
 };
 static const guint8 CORE_GET_CONFIG_RSP_DISCOVERY_RW[] = {
-    0x40, 0x03, 0x08, 0x00, 0x02,
+    0x40, 0x03, 0x0e, 0x00, 0x03,
+    0x33, 0x04, 0x08, 0x00, 0x00, 0x00, /* LA_NFCID1 (dynamic) */
     0x32, 0x01, 0x00, /* LA_SEL_INFO = 0 */
     0x50, 0x01, 0x00  /* LF_PROTOCOL_TYPE = 0 */
 };
 static const guint8 CORE_GET_CONFIG_RSP_DISCOVERY_PEER[] = {
-    0x40, 0x03, 0x08, 0x00, 0x02,
+    0x40, 0x03, 0x0e, 0x00, 0x03,
+    0x33, 0x04, 0x08, 0x00, 0x00, 0x00, /* LA_NFCID1 (dynamic) */
     0x32, 0x01, 0x40, /* LA_SEL_INFO = 0x40 */
     0x50, 0x01, 0x02  /* LF_PROTOCOL_TYPE = 0x02 */
 };
 static const guint8 CORE_GET_CONFIG_RSP_DISCOVERY_CE_PEER[] = {
-    0x40, 0x03, 0x08, 0x00, 0x02,
+    0x40, 0x03, 0x0e, 0x00, 0x03,
+    0x33, 0x04, 0x08, 0x00, 0x00, 0x00, /* LA_NFCID1 (dynamic) */
     0x32, 0x01, 0x60, /* LA_SEL_INFO = 0x60 */
     0x50, 0x01, 0x02  /* LF_PROTOCOL_TYPE = 0x02 */
 };
 static const guint8 CORE_GET_CONFIG_RSP_DISCOVERY_CE_A[] = {
-    0x40, 0x03, 0x08, 0x00, 0x02,
+    0x40, 0x03, 0x0e, 0x00, 0x03,
+    0x33, 0x04, 0x08, 0x00, 0x00, 0x00, /* LA_NFCID1 (dynamic) */
     0x32, 0x01, 0x60, /* LA_SEL_INFO = 0x60 */
     0x50, 0x01, 0x00  /* LF_PROTOCOL_TYPE = 0x00 */
 };
 static const guint8 CORE_GET_CONFIG_RSP_ERROR[] = {
     0x40, 0x03, 0x02, 0x03, 0x00
+};
+static const guint8 CORE_SET_CONFIG_CMD_DISCOVERY_RW_FULL[] = {
+    0x20, 0x02, 0x0d, 0x03,
+    0x33, 0x04, 0x08, 0x00, 0x00, 0x00, /* LA_NFCID1 (dynamic) */
+    0x32, 0x01, 0x00, /* LA_SEL_INFO = 0 */
+    0x50, 0x01, 0x00  /* LF_PROTOCOL_TYPE = 0 */
 };
 static const guint8 CORE_SET_CONFIG_CMD_DISCOVERY_RW[] = {
     0x20, 0x02, 0x07, 0x02,
@@ -228,9 +240,13 @@ static const guint8 CORE_SET_CONFIG_CMD_DISCOVERY_PEER[] = {
     0x50, 0x01, 0x02  /* LF_PROTOCOL_TYPE = 0x02 */
 };
 static const guint8 CORE_SET_CONFIG_CMD_DISCOVERY_CE[] = {
-    0x20, 0x02, 0x07, 0x02,
-    0x32, 0x01, 0x20, /* LA_SEL_INFO = 0x20 */
-    0x50, 0x01, 0x00  /* LF_PROTOCOL_TYPE = 0x00 */
+    0x20, 0x02, 0x04, 0x01,
+    0x32, 0x01, 0x20  /* LA_SEL_INFO = 0x20 */
+};
+static const guint8 CORE_SET_CONFIG_CMD_LA_NFCID_01020304050607[] = {
+    0x20, 0x02, 0x0d, 0x02,
+    0x33, 0x07, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, /* LA_NFCID */
+    0x32, 0x01, 0x20  /* LA_SEL_INFO = 0x20 */
 };
 static const guint8 RF_SET_LISTEN_MODE_ROUTING_CMD_MIXED_RW_PEER[] = {
     0x21, 0x01, 0x1b, 0x00, 0x05,
@@ -1839,6 +1855,13 @@ static const NciCoreParam TEST_PARAM_INVAL = {
 static const NciCoreParam* const TEST_PARAMS_VERSION_10_WKS_100_INVAL[] = {
     &TEST_PARAM_VERSION_10, &TEST_PARAM_WKS_100, &TEST_PARAM_INVAL, NULL
 };
+static const NciCoreParam TEST_PARAM_LA_NFCID_01020304050607 = {
+    .key = NCI_CORE_PARAM_LA_NFCID1,
+    .value.nfcid1 = { 7, { 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07 } }
+};
+static const NciCoreParam* const TEST_PARAMS_LA_NFCID_01020304050607[] = {
+    &TEST_PARAM_LA_NFCID_01020304050607, NULL
+};
 
 static const TestSmEntry test_nci_sm_init_params[] = {
     TEST_NCI_SM_SET_PARAMS(TEST_PARAMS_VERSION_10_WKS_100_INVAL, FALSE),
@@ -2071,7 +2094,7 @@ static const TestSmEntry test_nci_sm_discovery_invalid_param[] = {
     TEST_NCI_SM_ASSERT_STATES(NCI_RFST_IDLE, NCI_RFST_DISCOVERY),
     TEST_NCI_SM_EXPECT_CMD(CORE_GET_CONFIG_CMD_DISCOVERY),
     TEST_NCI_SM_QUEUE_RSP(CORE_GET_CONFIG_RSP_DISCOVERY_INVALID_PARAM),
-    TEST_NCI_SM_EXPECT_CMD(CORE_SET_CONFIG_CMD_DISCOVERY_RW),
+    TEST_NCI_SM_EXPECT_CMD(CORE_SET_CONFIG_CMD_DISCOVERY_RW_FULL),
     TEST_NCI_SM_QUEUE_RSP(CORE_SET_CONFIG_RSP),  /* Peer modes off */
 
     TEST_NCI_SM_EXPECT_CMD(RF_DISCOVER_MAP_CMD_RW),
@@ -2099,7 +2122,7 @@ static const TestSmEntry test_nci_sm_discovery_get_config_error[] = {
     TEST_NCI_SM_ASSERT_STATES(NCI_RFST_IDLE, NCI_RFST_DISCOVERY),
     TEST_NCI_SM_EXPECT_CMD(CORE_GET_CONFIG_CMD_DISCOVERY),
     TEST_NCI_SM_QUEUE_RSP(CORE_GET_CONFIG_RSP_ERROR),
-    TEST_NCI_SM_EXPECT_CMD(CORE_SET_CONFIG_CMD_DISCOVERY_RW),
+    TEST_NCI_SM_EXPECT_CMD(CORE_SET_CONFIG_CMD_DISCOVERY_RW_FULL),
     TEST_NCI_SM_QUEUE_RSP(CORE_SET_CONFIG_RSP),  /* Peer modes off */
 
     TEST_NCI_SM_EXPECT_CMD(RF_DISCOVER_MAP_CMD_RW),
@@ -4001,6 +4024,8 @@ static const TestSmEntry test_nci_sm_discovery_rw_ce[] = {
     TEST_NCI_SM_ASSERT_STATES(NCI_RFST_IDLE, NCI_RFST_DISCOVERY),
     TEST_NCI_SM_EXPECT_CMD(CORE_GET_CONFIG_CMD_DISCOVERY),
     TEST_NCI_SM_QUEUE_RSP(CORE_GET_CONFIG_RSP_DISCOVERY_RW),
+    TEST_NCI_SM_EXPECT_CMD(CORE_SET_CONFIG_CMD_DISCOVERY_CE),
+    TEST_NCI_SM_QUEUE_RSP(CORE_SET_CONFIG_RSP),
     TEST_NCI_SM_EXPECT_CMD(RF_SET_LISTEN_MODE_ROUTING_CMD_MIXED_F_B_A),
     TEST_NCI_SM_QUEUE_RSP(RF_SET_LISTEN_MODE_ROUTING_RSP),
     TEST_NCI_SM_EXPECT_CMD(RF_DISCOVER_MAP_CMD_RW_CE),
@@ -4079,6 +4104,8 @@ static const TestSmEntry test_nci_sm_read_ce_ndef_ab[] = {
     TEST_NCI_SM_ASSERT_STATES(NCI_RFST_IDLE, NCI_RFST_DISCOVERY),
     TEST_NCI_SM_EXPECT_CMD(CORE_GET_CONFIG_CMD_DISCOVERY),
     TEST_NCI_SM_QUEUE_RSP(CORE_GET_CONFIG_RSP_DISCOVERY_RW),
+    TEST_NCI_SM_EXPECT_CMD(CORE_SET_CONFIG_CMD_DISCOVERY_CE),
+    TEST_NCI_SM_QUEUE_RSP(CORE_SET_CONFIG_RSP),
     TEST_NCI_SM_EXPECT_CMD(RF_SET_LISTEN_MODE_ROUTING_CMD_MIXED_CE_B_A),
     TEST_NCI_SM_QUEUE_RSP(RF_SET_LISTEN_MODE_ROUTING_RSP),
 
@@ -4106,6 +4133,38 @@ static const TestSmEntry test_nci_sm_read_ce_ndef_ab[] = {
     TEST_NCI_SM_QUEUE_NTF(RF_DEACTIVATE_NTF_SLEEP_EP_REQUEST),
     TEST_NCI_SM_WAIT_STATE(NCI_RFST_LISTEN_SLEEP),
 
+    TEST_NCI_SM_END()
+};
+
+static const TestSmEntry test_nci_param_la_nfcid1[] = {
+    TEST_NCI_SM_SET_PARAMS(TEST_PARAMS_LA_NFCID_01020304050607, FALSE),
+    TEST_NCI_SM_SET_OP_MODE(NFC_OP_MODE_CE),
+    TEST_NCI_SM_SET_STATE(NCI_RFST_DISCOVERY),
+    TEST_NCI_SM_ASSERT_STATES(NCI_STATE_INIT, NCI_RFST_DISCOVERY),
+
+    TEST_NCI_SM_EXPECT_CMD(CORE_RESET_CMD),
+    TEST_NCI_SM_QUEUE_RSP(CORE_RESET_V2_RSP),
+    TEST_NCI_SM_QUEUE_NTF(CORE_RESET_V2_NTF),
+    TEST_NCI_SM_EXPECT_CMD(CORE_INIT_CMD_V2),
+    TEST_NCI_SM_QUEUE_RSP(CORE_INIT_V2_RSP),
+    TEST_NCI_SM_EXPECT_CMD(CORE_SET_CONFIG_CMD_DEFAULT),
+    TEST_NCI_SM_QUEUE_RSP(CORE_SET_CONFIG_RSP),
+    TEST_NCI_SM_WAIT_STATE(NCI_RFST_IDLE),
+
+    TEST_NCI_SM_ASSERT_STATES(NCI_RFST_IDLE, NCI_RFST_DISCOVERY),
+    TEST_NCI_SM_EXPECT_CMD(CORE_GET_CONFIG_CMD_DISCOVERY),
+    TEST_NCI_SM_QUEUE_RSP(CORE_GET_CONFIG_RSP_DISCOVERY_RW),
+    TEST_NCI_SM_EXPECT_CMD(CORE_SET_CONFIG_CMD_LA_NFCID_01020304050607),
+    TEST_NCI_SM_QUEUE_RSP(CORE_SET_CONFIG_RSP),
+    TEST_NCI_SM_EXPECT_CMD(RF_SET_LISTEN_MODE_ROUTING_CMD_MIXED_CE_B_A),
+    TEST_NCI_SM_QUEUE_RSP(RF_SET_LISTEN_MODE_ROUTING_RSP),
+
+    TEST_NCI_SM_EXPECT_CMD(RF_DISCOVER_MAP_CMD_LISTEN_ISODEP),
+    TEST_NCI_SM_QUEUE_RSP(RF_DISCOVER_MAP_RSP),
+    TEST_NCI_SM_EXPECT_CMD(RF_DISCOVER_CMD_A_B_LISTEN),
+    TEST_NCI_SM_QUEUE_RSP(RF_DISCOVER_RSP),
+
+    TEST_NCI_SM_WAIT_STATE(NCI_RFST_DISCOVERY),
     TEST_NCI_SM_END()
 };
 
@@ -4253,6 +4312,37 @@ static const TestSmEntry test_nci_config_f_rw[] = {
     TEST_NCI_SM_END()
 };
 
+static const TestSmEntry test_nci_config_la_nfcid1[] = {
+    TEST_NCI_SM_SET_OP_MODE(NFC_OP_MODE_CE),
+    TEST_NCI_SM_SET_STATE(NCI_RFST_DISCOVERY),
+    TEST_NCI_SM_ASSERT_STATES(NCI_STATE_INIT, NCI_RFST_DISCOVERY),
+
+    TEST_NCI_SM_EXPECT_CMD(CORE_RESET_CMD),
+    TEST_NCI_SM_QUEUE_RSP(CORE_RESET_V2_RSP),
+    TEST_NCI_SM_QUEUE_NTF(CORE_RESET_V2_NTF),
+    TEST_NCI_SM_EXPECT_CMD(CORE_INIT_CMD_V2),
+    TEST_NCI_SM_QUEUE_RSP(CORE_INIT_V2_RSP),
+    TEST_NCI_SM_EXPECT_CMD(CORE_SET_CONFIG_CMD_DEFAULT),
+    TEST_NCI_SM_QUEUE_RSP(CORE_SET_CONFIG_RSP),
+    TEST_NCI_SM_WAIT_STATE(NCI_RFST_IDLE),
+
+    TEST_NCI_SM_ASSERT_STATES(NCI_RFST_IDLE, NCI_RFST_DISCOVERY),
+    TEST_NCI_SM_EXPECT_CMD(CORE_GET_CONFIG_CMD_DISCOVERY),
+    TEST_NCI_SM_QUEUE_RSP(CORE_GET_CONFIG_RSP_DISCOVERY_RW),
+    TEST_NCI_SM_EXPECT_CMD(CORE_SET_CONFIG_CMD_LA_NFCID_01020304050607),
+    TEST_NCI_SM_QUEUE_RSP(CORE_SET_CONFIG_RSP),
+    TEST_NCI_SM_EXPECT_CMD(RF_SET_LISTEN_MODE_ROUTING_CMD_MIXED_CE_B_A),
+    TEST_NCI_SM_QUEUE_RSP(RF_SET_LISTEN_MODE_ROUTING_RSP),
+
+    TEST_NCI_SM_EXPECT_CMD(RF_DISCOVER_MAP_CMD_LISTEN_ISODEP),
+    TEST_NCI_SM_QUEUE_RSP(RF_DISCOVER_MAP_RSP),
+    TEST_NCI_SM_EXPECT_CMD(RF_DISCOVER_CMD_A_B_LISTEN),
+    TEST_NCI_SM_QUEUE_RSP(RF_DISCOVER_RSP),
+
+    TEST_NCI_SM_WAIT_STATE(NCI_RFST_DISCOVERY),
+    TEST_NCI_SM_END()
+};
+
 static const char test_nci_config_ab_data_default[] = CONFIG_SECTION "\n";
 static const char test_nci_config_ab_data_junk[] = "junk";
 static const char test_nci_config_ab_data_empty[] =
@@ -4276,6 +4366,18 @@ static const char test_nci_config_b_data[] =
 static const char test_nci_config_f_data[] =
     CONFIG_SECTION "\n"
     CONFIG_ENTRY_TECHNOLOGIES " = F\n";
+static const char test_nci_config_ab_invalid_la_nfcid1_data1[] =
+    CONFIG_SECTION "\n"
+    CONFIG_ENTRY_TECHNOLOGIES " = A,B\n"
+    CONFIG_ENTRY_LA_NFCID1 " = 010203";
+static const char test_nci_config_ab_invalid_la_nfcid1_data2[] =
+    CONFIG_SECTION "\n"
+    CONFIG_ENTRY_TECHNOLOGIES " = A,B\n"
+    CONFIG_ENTRY_LA_NFCID1 " = Garbage!\n";
+static const char test_nci_config_la_nfcid1_data[] =
+    CONFIG_SECTION "\n"
+    CONFIG_ENTRY_TECHNOLOGIES " = A,B\n"
+    CONFIG_ENTRY_LA_NFCID1 " = 01020304050607\n";
 
 static const TestNciSmData nci_sm_tests[] = {
     { "init-ok", test_nci_sm_init_ok },
@@ -4352,6 +4454,11 @@ static const TestNciSmData nci_sm_tests[] = {
     { "discovery-rw_ce", test_nci_sm_discovery_rw_ce },
     { "set_mode-a", test_nci_sm_set_mode_a },
     { "read-ce-ndef-ab", test_nci_sm_read_ce_ndef_ab, test_nci_config_ab_data },
+    { "read-ce-ndef-ab-invalid_la_nfcid1_config1", test_nci_sm_read_ce_ndef_ab,
+       test_nci_config_ab_invalid_la_nfcid1_data1 },
+    { "read-ce-ndef-ab-invalid_la_nfcid1_config2", test_nci_sm_read_ce_ndef_ab,
+       test_nci_config_ab_invalid_la_nfcid1_data2 },
+    { "param_la_nfcid1", test_nci_param_la_nfcid1, test_nci_config_ab_data },
     { "config_default", test_nci_config_abf, test_nci_config_ab_data_default },
     { "config_empty", test_nci_config_abf, test_nci_config_ab_data_empty },
     { "config_junk", test_nci_config_abf, test_nci_config_ab_data_junk },
@@ -4360,7 +4467,9 @@ static const TestNciSmData nci_sm_tests[] = {
     { "config_ab_x", test_nci_config_ab_ce, test_nci_config_ab_data_x },
     { "config_a_rw", test_nci_config_a_rw, test_nci_config_a_data },
     { "config_b_rw", test_nci_config_b_rw, test_nci_config_b_data },
-    { "config_f_rw", test_nci_config_f_rw, test_nci_config_f_data }
+    { "config_f_rw", test_nci_config_f_rw, test_nci_config_f_data },
+    { "config_la_nfcid1", test_nci_config_la_nfcid1,
+       test_nci_config_la_nfcid1_data }
 };
 
 /*==========================================================================*

--- a/unit/nci_sm/test_nci_sm.c
+++ b/unit/nci_sm/test_nci_sm.c
@@ -231,6 +231,7 @@ test_null(
 
     nci_sm_free(null);
     nci_sm_set_op_mode(null, NFC_OP_MODE_NONE);
+    nci_sm_set_la_nfcid1(null, NULL);
     g_assert_cmpint(nci_sm_set_tech(NULL, NCI_TECH_A), == ,NCI_TECH_NONE);
     nci_sm_handle_ntf(null, 0, 0, NULL);
     nci_sm_add_state(null, NULL);

--- a/unit/nci_util/test_nci_util.c
+++ b/unit/nci_util/test_nci_util.c
@@ -55,6 +55,72 @@ test_null(
 }
 
 /*==========================================================================*
+ * nfcid1_dynamic
+ *==========================================================================*/
+
+static
+void
+test_nfcid1_dynamic(
+    void)
+{
+    static const NciNfcid1 nfcid1_dynamic_1 = { 0, { 0x00 } };
+    static const NciNfcid1 nfcid1_dynamic_2 = { 4, { 0x08, 0x00, 0x00, 0x00 } };
+    static const NciNfcid1 nfcid1_dynamic_3 = { 4, { 0x08, 0x01, 0x02, 0x03 } };
+
+    static const NciNfcid1 nfcid1_static_1 = { 4, { 0x01, 0x02, 0x03, 0x04 } };
+    static const NciNfcid1 nfcid1_static_2 = { 7, { 0 }};
+
+    g_assert(nci_nfcid1_dynamic(&nfcid1_dynamic_1));
+    g_assert(nci_nfcid1_dynamic(&nfcid1_dynamic_2));
+    g_assert(nci_nfcid1_dynamic(&nfcid1_dynamic_3));
+
+    g_assert(!nci_nfcid1_dynamic(&nfcid1_static_1));
+    g_assert(!nci_nfcid1_dynamic(&nfcid1_static_2));
+}
+
+/*==========================================================================*
+ * nfcid1_equal
+ *==========================================================================*/
+
+static
+void
+test_nfcid1_equal(
+    void)
+{
+    static const NciNfcid1 id1 = { 0, { 0x00 } };
+    static const NciNfcid1 id2 = { 4, { 0x08, 0x00, 0x00, 0x00 } };
+    static const NciNfcid1 id3 = { 4, { 0x08, 0x01, 0x02, 0x03 } };
+    static const NciNfcid1 id4 = { 4, { 0x01, 0x02, 0x03, 0x04 } };
+    static const NciNfcid1 id5 = { 4, { 0x02, 0x03, 0x04, 0x05 } };
+    static const NciNfcid1 id6 = { 7, { 0 }};
+    static const NciNfcid1 id7 = { 7, { 1 }};
+
+    /* Always equal to themselves */
+    g_assert(nci_nfcid1_equal(&id1, &id1));
+    g_assert(nci_nfcid1_equal(&id2, &id3));
+    g_assert(nci_nfcid1_equal(&id3, &id3));
+    g_assert(nci_nfcid1_equal(&id4, &id4));
+    g_assert(nci_nfcid1_equal(&id5, &id5));
+    g_assert(nci_nfcid1_equal(&id6, &id6));
+    g_assert(nci_nfcid1_equal(&id7, &id7));
+
+    /* All dynamic forms are equal */
+    g_assert(nci_nfcid1_equal(&id1, &id2));
+    g_assert(nci_nfcid1_equal(&id2, &id3));
+    g_assert(nci_nfcid1_equal(&id1, &id3));
+    g_assert(nci_nfcid1_equal(&id2, &id1));
+    g_assert(nci_nfcid1_equal(&id3, &id2));
+    g_assert(nci_nfcid1_equal(&id3, &id1));
+
+    g_assert(!nci_nfcid1_equal(&id1, &id4));
+    g_assert(!nci_nfcid1_equal(&id2, &id4));
+    g_assert(!nci_nfcid1_equal(&id3, &id4));
+    g_assert(!nci_nfcid1_equal(&id4, &id5));
+    g_assert(!nci_nfcid1_equal(&id5, &id6));
+    g_assert(!nci_nfcid1_equal(&id6, &id7));
+}
+
+/*==========================================================================*
  * listen_mode
  *==========================================================================*/
 
@@ -107,7 +173,6 @@ test_mode_param_success(
         test->data.bytes, test->data.size));
     g_assert(!memcmp(&param, &test->expected, sizeof(param)));
 }
-
 
 static const guint8 mode_param_success_data_minimal[] =
     { 0x04, 0x00, 0x00, 0x00 };
@@ -1501,6 +1566,8 @@ int main(int argc, char* argv[])
     g_test_init(&argc, &argv, NULL);
     test_init(&test_opt, argc, argv);
     g_test_add_func(TEST_("null"), test_null);
+    g_test_add_func(TEST_("nfcid1_dynamic"), test_nfcid1_dynamic);
+    g_test_add_func(TEST_("nfcid1_equal"), test_nfcid1_equal);
     g_test_add_func(TEST_("listen_mode"), test_listen_mode);
     for (i = 0; i < G_N_ELEMENTS(mode_param_success_tests); i++) {
         const TestModeParamSuccessData* test = mode_param_success_tests + i;


### PR DESCRIPTION
That's NFCID1 for Listen A mode. Can be configured either via config file or programmatically at run time. The default is `08xxxxxx` where `xx` bytes are dynamically generated by NFCC.