### PR TITLE
Update byte 1 of SENS_RES based on NFCID1 size

### DIFF
--- a/src/nci_sm.c
+++ b/src/nci_sm.c
@@ -2,32 +2,35 @@
  * Copyright (C) 2019-2023 Slava Monich <slava@monich.com>
  * Copyright (C) 2019-2021 Jolla Ltd.
  *
- * You may use this file under the terms of BSD license as follows:
+ * You may use this file under the terms of the BSD license as follows:
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
  * are met:
  *
- *   1. Redistributions of source code must retain the above copyright
- *      notice, this list of conditions and the following disclaimer.
- *   2. Redistributions in binary form must reproduce the above copyright
- *      notice, this list of conditions and the following disclaimer in the
- *      documentation and/or other materials provided with the distribution.
- *   3. Neither the names of the copyright holders nor the names of its
- *      contributors may be used to endorse or promote products derived
- *      from this software without specific prior written permission.
+ *  1. Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *  2. Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer
+ *     in the documentation and/or other materials provided with the
+ *     distribution.
+ *  3. Neither the names of the copyright holders nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
  *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS
- * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
- * THE POSSIBILITY OF SUCH DAMAGE.
+ * THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESSED OR IMPLIED
+ * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL THE CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) ARISING
+ * IN ANY WAY OUT OF THE USE OR INABILITY TO USE THIS SOFTWARE, EVEN
+ * IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * The views and conclusions contained in the software and documentation
+ * are those of the authors and should not be interpreted as representing
+ * any official policies, either expressed or implied.
  */
 
 #include "nci_sm.h"
@@ -490,11 +493,16 @@ nci_sm_parse_config(
 
         /* NFCID1 can be 4, 7, or 10 bytes long */
         switch (len) {
+        case 0:
+            memset(nfcid1, 0, sizeof(*nfcid1));
+            GDEBUG("  LA_NFCID1 (dynamic)");
+            break;
         case 8: case 14: case 20:
             if (gutil_hex2bin(sval, len, nfcid1->bytes)) {
                 nfcid1->len = len/2;
                 sm->la_nfcid1 = *nfcid1;
-                GDEBUG("  LA_NFCID1 %s", sval);
+                GDEBUG("  LA_NFCID1 %s", nci_nfcid1_dynamic(nfcid1) ?
+                    "(dynamic)" : sval);
                 break;
             } else {
                 /* Undo potential damage */
@@ -824,6 +832,11 @@ nci_sm_set_tech(
     return NCI_TECH_NONE;
 }
 
+/*
+ * N.B. This internal function is called by nci_core_set_params() which
+ * detects the changes and, if necessary, restarts the state machine to
+ * reconfigure NFCC.
+ */
 void
 nci_sm_set_la_nfcid1(
     NciSm* sm,

--- a/src/nci_sm.h
+++ b/src/nci_sm.h
@@ -66,6 +66,14 @@ typedef enum nci_nfcc_power {
     NCI_NFCC_POWER_SWITCH_OFF           = 0x02
 } NCI_NFCC_POWER;
 
+/* LA_SENS_RES_1 (Byte 1 of SENS_RES) coding */
+typedef enum nci_la_sens_res_1 {
+    NCI_LA_SENS_RES_NFCID1_LEN_4        = 0x00,
+    NCI_LA_SENS_RES_NFCID1_LEN_7        = 0x40,
+    NCI_LA_SENS_RES_NFCID1_LEN_10       = 0x80,
+    NCI_LA_SENS_RES_NFCID1_LEN_MASK     = 0xc0
+} NCI_LA_SENS_RES_1;
+
 /* LA_SEL_INFO coding */
 typedef enum nci_la_sel_info {
     NCI_LA_SEL_INFO_ISO_DEP            = 0x20,

--- a/unit/nci_core/test_nci_core.c
+++ b/unit/nci_core/test_nci_core.c
@@ -2,32 +2,35 @@
  * Copyright (C) 2018-2023 Slava Monich <slava@monich.com>
  * Copyright (C) 2018-2021 Jolla Ltd.
  *
- * You may use this file under the terms of BSD license as follows:
+ * You may use this file under the terms of the BSD license as follows:
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
  * are met:
  *
- *   1. Redistributions of source code must retain the above copyright
- *      notice, this list of conditions and the following disclaimer.
- *   2. Redistributions in binary form must reproduce the above copyright
- *      notice, this list of conditions and the following disclaimer in the
- *      documentation and/or other materials provided with the distribution.
- *   3. Neither the names of the copyright holders nor the names of its
- *      contributors may be used to endorse or promote products derived
- *      from this software without specific prior written permission.
+ *  1. Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *  2. Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer
+ *     in the documentation and/or other materials provided with the
+ *     distribution.
+ *  3. Neither the names of the copyright holders nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
  *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS
- * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
- * THE POSSIBILITY OF SUCH DAMAGE.
+ * THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESSED OR IMPLIED
+ * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL THE CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) ARISING
+ * IN ANY WAY OUT OF THE USE OR INABILITY TO USE THIS SOFTWARE, EVEN
+ * IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * The views and conclusions contained in the software and documentation
+ * are those of the authors and should not be interpreted as representing
+ * any official policies, either expressed or implied.
  */
 
 #include "test_common.h"
@@ -189,33 +192,50 @@ static const guint8 CORE_SET_CONFIG_RSP_ERROR[] = {
     0x40, 0x02, 0x02, NCI_STATUS_REJECTED, 0x00
 };
 static const guint8 CORE_GET_CONFIG_CMD_DISCOVERY[] = {
-    /* LA_NFCID1, LA_SEL_INFO, LF_PROTOCOL_TYPE */
-    0x20, 0x03, 0x04, 0x03, 0x33, 0x32, 0x50
+    /* LA_SENS_RES_1, LA_NFCID1, LA_SEL_INFO, LF_PROTOCOL_TYPE */
+    0x20, 0x03, 0x05, 0x04, 0x30, 0x33, 0x32, 0x50
 };
 static const guint8 CORE_GET_CONFIG_RSP_DISCOVERY_INVALID_PARAM[] = {
     0x40, 0x03, 0x06, NCI_STATUS_INVALID_PARAM, 0x02,
     0x32, 0x00, 0x50, 0x00
 };
+static const guint8 CORE_GET_CONFIG_RSP_NO_LA_SENS_RES_1[] = {
+    0x40, 0x03, 0x0e, 0x00, 0x04,
+    0x33, 0x04, 0x08, 0x00, 0x00, 0x00, /* LA_NFCID1 (dynamic) */
+    0x32, 0x01, 0x00, /* LA_SEL_INFO = 0 */
+    0x50, 0x01, 0x00  /* LF_PROTOCOL_TYPE = 0 */
+};
+static const guint8 CORE_GET_CONFIG_RSP_NFCID_01020304050607[] = {
+    0x40, 0x03, 0x14, 0x00, 0x04,
+    0x30, 0x01, 0x44, /* LA_SENS_RES_1 (7 bytes NFCID1) */
+    0x33, 0x07, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, /* LA_NFCID1 */
+    0x32, 0x01, 0x00, /* LA_SEL_INFO = 0 */
+    0x50, 0x01, 0x00  /* LF_PROTOCOL_TYPE = 0 */
+};
 static const guint8 CORE_GET_CONFIG_RSP_DISCOVERY_RW[] = {
-    0x40, 0x03, 0x0e, 0x00, 0x03,
+    0x40, 0x03, 0x11, 0x00, 0x04,
+    0x30, 0x01, 0x04, /* LA_SENS_RES_1 (4 bytes NFCID1) */
     0x33, 0x04, 0x08, 0x00, 0x00, 0x00, /* LA_NFCID1 (dynamic) */
     0x32, 0x01, 0x00, /* LA_SEL_INFO = 0 */
     0x50, 0x01, 0x00  /* LF_PROTOCOL_TYPE = 0 */
 };
 static const guint8 CORE_GET_CONFIG_RSP_DISCOVERY_PEER[] = {
-    0x40, 0x03, 0x0e, 0x00, 0x03,
+    0x40, 0x03, 0x11, 0x00, 0x04,
+    0x30, 0x01, 0x04, /* LA_SENS_RES_1 (4 bytes NFCID1) */
     0x33, 0x04, 0x08, 0x00, 0x00, 0x00, /* LA_NFCID1 (dynamic) */
     0x32, 0x01, 0x40, /* LA_SEL_INFO = 0x40 */
     0x50, 0x01, 0x02  /* LF_PROTOCOL_TYPE = 0x02 */
 };
 static const guint8 CORE_GET_CONFIG_RSP_DISCOVERY_CE_PEER[] = {
-    0x40, 0x03, 0x0e, 0x00, 0x03,
+    0x40, 0x03, 0x11, 0x00, 0x04,
+    0x30, 0x01, 0x04, /* LA_SENS_RES_1 (4 bytes NFCID1) */
     0x33, 0x04, 0x08, 0x00, 0x00, 0x00, /* LA_NFCID1 (dynamic) */
     0x32, 0x01, 0x60, /* LA_SEL_INFO = 0x60 */
     0x50, 0x01, 0x02  /* LF_PROTOCOL_TYPE = 0x02 */
 };
 static const guint8 CORE_GET_CONFIG_RSP_DISCOVERY_CE_A[] = {
-    0x40, 0x03, 0x0e, 0x00, 0x03,
+    0x40, 0x03, 0x11, 0x00, 0x04,
+    0x30, 0x01, 0x04, /* LA_SENS_RES_1 (4 bytes NFCID1) */
     0x33, 0x04, 0x08, 0x00, 0x00, 0x00, /* LA_NFCID1 (dynamic) */
     0x32, 0x01, 0x60, /* LA_SEL_INFO = 0x60 */
     0x50, 0x01, 0x00  /* LF_PROTOCOL_TYPE = 0x00 */
@@ -224,7 +244,8 @@ static const guint8 CORE_GET_CONFIG_RSP_ERROR[] = {
     0x40, 0x03, 0x02, 0x03, 0x00
 };
 static const guint8 CORE_SET_CONFIG_CMD_DISCOVERY_RW_FULL[] = {
-    0x20, 0x02, 0x0d, 0x03,
+    0x20, 0x02, 0x10, 0x04,
+    0x30, 0x01, 0x00, /* LA_SENS_RES_1 (4 bytes NFCID1) */
     0x33, 0x04, 0x08, 0x00, 0x00, 0x00, /* LA_NFCID1 (dynamic) */
     0x32, 0x01, 0x00, /* LA_SEL_INFO = 0 */
     0x50, 0x01, 0x00  /* LF_PROTOCOL_TYPE = 0 */
@@ -243,9 +264,22 @@ static const guint8 CORE_SET_CONFIG_CMD_DISCOVERY_CE[] = {
     0x20, 0x02, 0x04, 0x01,
     0x32, 0x01, 0x20  /* LA_SEL_INFO = 0x20 */
 };
-static const guint8 CORE_SET_CONFIG_CMD_LA_NFCID_01020304050607[] = {
-    0x20, 0x02, 0x0d, 0x02,
-    0x33, 0x07, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, /* LA_NFCID */
+static const guint8 CORE_SET_CONFIG_CMD_NFCID_01020304050607_1[] = {
+    0x20, 0x02, 0x10, 0x03,
+    0x30, 0x01, 0x40, /* Default LA_SENS_RES_1 for 7 bytes NFCID1 */
+    0x33, 0x07, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, /* LA_NFCID1 */
+    0x32, 0x01, 0x20  /* LA_SEL_INFO = 0x20 */
+};
+static const guint8 CORE_SET_CONFIG_CMD_NFCID_01020304050607_2[] = {
+    0x20, 0x02, 0x10, 0x03,
+    0x30, 0x01, 0x44, /* LA_SENS_RES_1 (7 bytes NFCID1) */
+    0x33, 0x07, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, /* LA_NFCID1 */
+    0x32, 0x01, 0x20  /* LA_SEL_INFO = 0x20 */
+};
+static const guint8 CORE_SET_CONFIG_CMD_NFCID_DYNAMIC[] = {
+    0x20, 0x02, 0x0d, 0x03,
+    0x30, 0x01, 0x04, /* LA_SENS_RES_1 for dynamic 4 bytes NFCID1 */
+    0x33, 0x04, 0x08, 0x00, 0x00, 0x00, /* LA_NFCID1 (dynamic) */
     0x32, 0x01, 0x20  /* LA_SEL_INFO = 0x20 */
 };
 static const guint8 RF_SET_LISTEN_MODE_ROUTING_CMD_MIXED_RW_PEER[] = {
@@ -4036,8 +4070,8 @@ static const TestSmEntry test_nci_param_la_nfcid1[] = {
 
     TEST_NCI_SM_ASSERT_STATES(NCI_RFST_IDLE, NCI_RFST_DISCOVERY),
     TEST_NCI_SM_EXPECT_CMD(CORE_GET_CONFIG_CMD_DISCOVERY),
-    TEST_NCI_SM_QUEUE_RSP(CORE_GET_CONFIG_RSP_DISCOVERY_RW),
-    TEST_NCI_SM_EXPECT_CMD(CORE_SET_CONFIG_CMD_LA_NFCID_01020304050607),
+    TEST_NCI_SM_QUEUE_RSP(CORE_GET_CONFIG_RSP_NO_LA_SENS_RES_1),
+    TEST_NCI_SM_EXPECT_CMD(CORE_SET_CONFIG_CMD_NFCID_01020304050607_1),
     TEST_NCI_SM_QUEUE_RSP(CORE_SET_CONFIG_RSP),
     TEST_NCI_SM_EXPECT_CMD(RF_SET_LISTEN_MODE_ROUTING_CMD_MIXED_CE_B_A),
     TEST_NCI_SM_QUEUE_RSP(RF_SET_LISTEN_MODE_ROUTING_RSP),
@@ -4195,6 +4229,37 @@ static const TestSmEntry test_nci_config_f_rw[] = {
     TEST_NCI_SM_END()
 };
 
+static const TestSmEntry test_nci_config_la_nfcid1_dynamic[] = {
+    TEST_NCI_SM_SET_OP_MODE(NFC_OP_MODE_CE),
+    TEST_NCI_SM_SET_STATE(NCI_RFST_DISCOVERY),
+    TEST_NCI_SM_ASSERT_STATES(NCI_STATE_INIT, NCI_RFST_DISCOVERY),
+
+    TEST_NCI_SM_EXPECT_CMD(CORE_RESET_CMD),
+    TEST_NCI_SM_QUEUE_RSP(CORE_RESET_V2_RSP),
+    TEST_NCI_SM_QUEUE_NTF(CORE_RESET_V2_NTF),
+    TEST_NCI_SM_EXPECT_CMD(CORE_INIT_CMD_V2),
+    TEST_NCI_SM_QUEUE_RSP(CORE_INIT_V2_RSP),
+    TEST_NCI_SM_EXPECT_CMD(CORE_SET_CONFIG_CMD_DEFAULT),
+    TEST_NCI_SM_QUEUE_RSP(CORE_SET_CONFIG_RSP),
+    TEST_NCI_SM_WAIT_STATE(NCI_RFST_IDLE),
+
+    TEST_NCI_SM_ASSERT_STATES(NCI_RFST_IDLE, NCI_RFST_DISCOVERY),
+    TEST_NCI_SM_EXPECT_CMD(CORE_GET_CONFIG_CMD_DISCOVERY),
+    TEST_NCI_SM_QUEUE_RSP(CORE_GET_CONFIG_RSP_NFCID_01020304050607),
+    TEST_NCI_SM_EXPECT_CMD(CORE_SET_CONFIG_CMD_NFCID_DYNAMIC),
+    TEST_NCI_SM_QUEUE_RSP(CORE_SET_CONFIG_RSP),
+    TEST_NCI_SM_EXPECT_CMD(RF_SET_LISTEN_MODE_ROUTING_CMD_MIXED_CE_B_A),
+    TEST_NCI_SM_QUEUE_RSP(RF_SET_LISTEN_MODE_ROUTING_RSP),
+
+    TEST_NCI_SM_EXPECT_CMD(RF_DISCOVER_MAP_CMD_LISTEN_ISODEP),
+    TEST_NCI_SM_QUEUE_RSP(RF_DISCOVER_MAP_RSP),
+    TEST_NCI_SM_EXPECT_CMD(RF_DISCOVER_CMD_A_B_LISTEN),
+    TEST_NCI_SM_QUEUE_RSP(RF_DISCOVER_RSP),
+
+    TEST_NCI_SM_WAIT_STATE(NCI_RFST_DISCOVERY),
+    TEST_NCI_SM_END()
+};
+
 static const TestSmEntry test_nci_config_la_nfcid1[] = {
     TEST_NCI_SM_SET_OP_MODE(NFC_OP_MODE_CE),
     TEST_NCI_SM_SET_STATE(NCI_RFST_DISCOVERY),
@@ -4212,7 +4277,7 @@ static const TestSmEntry test_nci_config_la_nfcid1[] = {
     TEST_NCI_SM_ASSERT_STATES(NCI_RFST_IDLE, NCI_RFST_DISCOVERY),
     TEST_NCI_SM_EXPECT_CMD(CORE_GET_CONFIG_CMD_DISCOVERY),
     TEST_NCI_SM_QUEUE_RSP(CORE_GET_CONFIG_RSP_DISCOVERY_RW),
-    TEST_NCI_SM_EXPECT_CMD(CORE_SET_CONFIG_CMD_LA_NFCID_01020304050607),
+    TEST_NCI_SM_EXPECT_CMD(CORE_SET_CONFIG_CMD_NFCID_01020304050607_2),
     TEST_NCI_SM_QUEUE_RSP(CORE_SET_CONFIG_RSP),
     TEST_NCI_SM_EXPECT_CMD(RF_SET_LISTEN_MODE_ROUTING_CMD_MIXED_CE_B_A),
     TEST_NCI_SM_QUEUE_RSP(RF_SET_LISTEN_MODE_ROUTING_RSP),
@@ -4261,6 +4326,10 @@ static const char test_nci_config_la_nfcid1_data[] =
     CONFIG_SECTION "\n"
     CONFIG_ENTRY_TECHNOLOGIES " = A,B\n"
     CONFIG_ENTRY_LA_NFCID1 " = 01020304050607\n";
+static const char test_nci_config_la_nfcid1_dynamic_data[] =
+    CONFIG_SECTION "\n"
+    CONFIG_ENTRY_TECHNOLOGIES " = A,B\n"
+    CONFIG_ENTRY_LA_NFCID1 " = \n";
 
 static const TestNciSmData nci_sm_tests[] = {
     { "init-ok", test_nci_sm_init_ok },
@@ -4349,7 +4418,9 @@ static const TestNciSmData nci_sm_tests[] = {
     { "config_b_rw", test_nci_config_b_rw, test_nci_config_b_data },
     { "config_f_rw", test_nci_config_f_rw, test_nci_config_f_data },
     { "config_la_nfcid1", test_nci_config_la_nfcid1,
-       test_nci_config_la_nfcid1_data }
+       test_nci_config_la_nfcid1_data },
+    { "config_la_nfcid1_dynamic", test_nci_config_la_nfcid1_dynamic,
+       test_nci_config_la_nfcid1_dynamic_data }
 };
 
 /*==========================================================================*


### PR DESCRIPTION
`NFCForum-TS-DigitalProtocol-1.0` specifies that bits b8 and b7 of byte 1 of `SENS_RES` must match the size of `NFCID1`:
```
4.6.3 SENS_RES Response

Table 7: Byte 1 of SENS_RES

+===========================================================+
| b8 b7 b6 b5 b4 b3 b2 b1  | Meaning                        |
+===========================================================+
| 0  0                     | NFCID1 size: single (4 bytes)  |
| 0  1                     | NFCID1 size: double (7 bytes)  |
| 1  0                     | NFCID1 size: triple (10 bytes) |
| 1  1                     | RFU                            |
| ...                                                       |
+===========================================================+
```
If there's a mismatch, some hosts refuse to talk to the tag.