### PR TITLE
Use CR field of the Data Packet header

### DIFF
--- a/unit/nci_sar/test_nci_sar.c
+++ b/unit/nci_sar/test_nci_sar.c
@@ -1,33 +1,36 @@
 /*
+ * Copyright (C) 2018-2023 Slava Monich <slava@monich.com>
  * Copyright (C) 2018-2020 Jolla Ltd.
- * Copyright (C) 2018-2020 Slava Monich <slava.monich@jolla.com>
  *
- * You may use this file under the terms of BSD license as follows:
+ * You may use this file under the terms of the BSD license as follows:
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
  * are met:
  *
- *   1. Redistributions of source code must retain the above copyright
- *      notice, this list of conditions and the following disclaimer.
- *   2. Redistributions in binary form must reproduce the above copyright
- *      notice, this list of conditions and the following disclaimer in the
- *      documentation and/or other materials provided with the distribution.
- *   3. Neither the names of the copyright holders nor the names of its
- *      contributors may be used to endorse or promote products derived
- *      from this software without specific prior written permission.
+ *  1. Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *  2. Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer
+ *     in the documentation and/or other materials provided with the
+ *     distribution.
+ *  3. Neither the names of the copyright holders nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
  *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS
- * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
- * THE POSSIBILITY OF SUCH DAMAGE.
+ * THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESSED OR IMPLIED
+ * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL THE CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) ARISING
+ * IN ANY WAY OUT OF THE USE OR INABILITY TO USE THIS SOFTWARE, EVEN
+ * IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * The views and conclusions contained in the software and documentation
+ * are those of the authors and should not be interpreted as representing
+ * any official policies, either expressed or implied.
  */
 
 #include "test_common.h"
@@ -1621,6 +1624,97 @@ test_reset(
 }
 
 /*==========================================================================*
+ * recv_cr
+ *==========================================================================*/
+
+typedef struct test_recv_cr {
+    NciSarClient client;
+    GMainLoop* loop;
+    int send_count;
+    int recv_count;
+} TestRecvCr;
+
+static
+void
+test_recv_cr_expect_success_and_quit(
+    NciSarClient* client,
+    gboolean success,
+    gpointer user_data)
+{
+    TestRecvCr* test = G_CAST(client, TestRecvCr, client);
+
+    g_assert(success);
+    g_assert(user_data == test);
+    g_assert_cmpint(test->send_count, == ,0);
+    g_assert_cmpint(test->recv_count, == ,1);
+    test->send_count++;
+    g_main_loop_quit(test->loop);
+}
+
+static
+void
+test_recv_cr_handle_packet(
+    NciSarClient* client,
+    guint8 cid,
+    const void* payload,
+    guint payload_len)
+{
+    TestRecvCr* test = G_CAST(client, TestRecvCr, client);
+    static const guint8 expected[] = { 0x01 };
+
+    GDEBUG("%u byte(s) received", payload_len);
+    g_assert_cmpint(test->send_count, == ,0);
+    g_assert_cmpint(test->recv_count, == ,0);
+    g_assert_cmpuint(cid, == ,0);
+    g_assert_cmpuint(payload_len, == ,sizeof(expected));
+    g_assert(!memcmp(payload, expected, payload_len));
+    test->recv_count++;
+}
+
+static
+void
+test_recv_cr(
+    void)
+{
+    static const NciSarClientFunctions test_recv_data_fn = {
+        .error = test_dummy_sar_client_error,
+        .handle_response = test_sar_client_unexpected_resp,
+        .handle_notification = test_sar_client_unexpected_resp,
+        .handle_data_packet = test_recv_cr_handle_packet
+    };
+    static const guint8 packet[] = {
+        NCI_MT_DATA_PKT | NCI_STATIC_RF_CONN_ID, 1 /* One credit */,  1, 0x01
+    };
+    static const guint8 data[] = { 0x02, 0x03 };
+    GBytes* bytes = g_bytes_new_static(data, sizeof(data));
+    NciSar* sar;
+    TestHalIo* test_io = test_hal_io_new();
+    TestRecvCr test;
+
+    memset(&test, 0, sizeof(test));
+    test.client.fn = &test_recv_data_fn;
+    test.loop = g_main_loop_new(NULL, TRUE);
+
+    sar = nci_sar_new(&test_io->io, &test.client);
+    nci_sar_set_max_data_payload_size(sar, 0xff);
+    g_assert(nci_sar_start(sar));
+    g_assert(test_io->sar);
+
+    /* Send will be unblocked by the data packet with a credit */
+    g_assert(nci_sar_send_data_packet(sar, NCI_STATIC_RF_CONN_ID,
+        bytes, test_recv_cr_expect_success_and_quit, NULL, &test));
+    test_io->sar->fn->read(test_io->sar, packet, sizeof(packet));
+
+    test_run_loop(&test_opt, test.loop);
+    g_assert_cmpint(test.send_count, == ,1);
+    g_assert_cmpint(test.recv_count, == ,1);
+
+    nci_sar_free(sar);
+    test_hal_io_free(test_io);
+    g_main_loop_unref(test.loop);
+}
+
+/*==========================================================================*
  * Common
  *==========================================================================*/
 
@@ -1646,6 +1740,7 @@ int main(int argc, char* argv[])
     g_test_add_func(TEST_("recv_data"), test_recv_data);
     g_test_add_func(TEST_("recv_data_seg"), test_recv_data_seg);
     g_test_add_func(TEST_("recv_reset"), test_reset);
+    g_test_add_func(TEST_("recv_cr"), test_recv_cr);
     test_init(&test_opt, argc, argv);
     return g_test_run();
 }


### PR DESCRIPTION
This field has appeared in NCI 2.0 spec. It's typically set to 0 even by the controllers which support NCI 2.0