### PR TITLE
Make reset more reliable

### DIFF
--- a/src/nci_core.c
+++ b/src/nci_core.c
@@ -364,8 +364,7 @@ nci_core_restart_internal(
 {
     nci_core_cancel_command(self);
     nci_sar_reset(self->io.sar);
-    nci_sm_enter_state(self->sm, NCI_STATE_INIT, NULL);
-    nci_sm_switch_to(self->sm, NCI_RFST_IDLE);
+    nci_sm_reset(self->sm);
 }
 
 /*==========================================================================*

--- a/src/nci_sm.h
+++ b/src/nci_sm.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2024 Slava Monich <slava@monich.com>
+ * Copyright (C) 2019-2025 Slava Monich <slava@monich.com>
  * Copyright (C) 2019-2021 Jolla Ltd.
  *
  * You may use this file under the terms of the BSD license as follows:
@@ -116,6 +116,11 @@ nci_sm_new(
 
 void
 nci_sm_free(
+    NciSm* sm)
+    NCI_INTERNAL;
+
+void
+nci_sm_reset(
     NciSm* sm)
     NCI_INTERNAL;
 


### PR DESCRIPTION
Tweaking NFCC parameters reset the state machine, which can happen at any moment - when the next transition has already been scheduled or even the point when the command has been sent to NFCC but no reply received yet. Those corner cases were not handled properly.