### PR TITLE
Make ATS Historical Bytes in Listen A mode configurable

### DIFF
--- a/include/nci_core.h
+++ b/include/nci_core.h
@@ -61,6 +61,7 @@ typedef enum nci_core_param_key {
     NCI_CORE_PARAM_LLC_VERSION, /* uint8, default is 0x11 (v1.1) */
     NCI_CORE_PARAM_LLC_WKS,     /* uint16, default is 0x0003 (SDP-only) */
     NCI_CORE_PARAM_LA_NFCID1,   /* nfcid1, default is dynamic (Since 1.1.22) */
+    NCI_CORE_PARAM_LI_A_HB,     /* hb, default is empty (Since 1.1.31) */
     NCI_CORE_PARAM_COUNT
 } NCI_CORE_PARAM; /* Since 1.1.18 */
 
@@ -69,7 +70,8 @@ typedef union nci_core_param_value {
     guint16 uint16;
     guint32 uint32;
     NciNfcid1 nfcid1; /* Since 1.1.22 */
-} NciCoreParamValue; /* Since 1.1.18 */
+    NciAtsHb hb;      /* Since 1.1.31 */
+} NciCoreParamValue;  /* Since 1.1.18 */
 
 typedef struct nci_core_param {
     NCI_CORE_PARAM key;

--- a/include/nci_types.h
+++ b/include/nci_types.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-2024 Slava Monich <slava@monich.com>
+ * Copyright (C) 2018-2025 Slava Monich <slava@monich.com>
  * Copyright (C) 2018-2020 Jolla Ltd.
  *
  * You may use this file under the terms of the BSD license as follows:
@@ -285,6 +285,27 @@ typedef struct nci_nfcid {
     guint8 len;
     guint8 bytes[10];
 } NciNfcid1; /* Since 1.1.22 */
+
+/*
+ * ATS (Answer To Select) HB (Historical Bytes), up to 15 bytes
+ * as suggested by the NFC forum spec:
+ *
+ * [NFCForum-TS-DigitalProtocol-1.0]
+ * Requirements 142: Historical Bytes of the ATS
+ *
+ * +=========================================================================+
+ * | Poll Mode                          | Listen Mode                        |
+ * +=========================================================================+
+ * | 11.6.2.23                          | 11.6.2.24                          |
+ * | The NFC Forum Device MUST be ready | The NFC Forum Device MUST send     |
+ * | to receive an ATS with up to 15    | no more than 15 historical bytes.  |
+ * | historical bytes.                  |                                    |
+ * +=========================================================================+
+ */
+typedef struct nci_ats_hb {
+    guint8 len;
+    guint8 bytes[15];
+} NciAtsHb; /* Since 1.1.31 */
 
 /* This is essentially NCI_MODE as a bitmask */
 

--- a/src/nci_core.c
+++ b/src/nci_core.c
@@ -399,6 +399,20 @@ nci_core_param_equal_nfcid(
 }
 
 static
+gboolean
+nci_core_param_equal_hb(
+    const NciCoreParamValue* v1,
+    const NciCoreParamValue* v2)
+{
+    const NciAtsHb* hb1 = &v1->hb;
+    const NciAtsHb* hb2 = &v2->hb;
+
+    /* Compare no more than 15 bytes */
+    return hb1->len == hb2->len && !memcmp(hb1->bytes, hb2->bytes,
+        MIN(hb1->len, sizeof(hb1->bytes)));
+}
+
+static
 void
 nci_core_param_get_llc_version(
     NciCoreObject* core,
@@ -480,7 +494,7 @@ nci_core_param_get_la_nfcid1(
     const NciNfcid1* nfcid = &core->sm->la_nfcid1;
 
     value->nfcid1.len = MIN(nfcid->len, sizeof(nfcid->bytes));
-    memcpy(value->nfcid1.bytes, nfcid->bytes, nfcid->len);
+    memcpy(value->nfcid1.bytes, nfcid->bytes, value->nfcid1.len);
 }
 
 static
@@ -498,6 +512,35 @@ nci_core_param_reset_la_nfcid1(
     NciCoreObject* core)
 {
     nci_sm_set_la_nfcid1(core->sm, NULL);
+}
+
+static
+void
+nci_core_param_get_li_a_hb(
+    NciCoreObject* core,
+    NciCoreParamValue* value)
+{
+    const NciAtsHb* hb = &core->sm->li_a_hb;
+
+    value->hb.len = MIN(hb->len, sizeof(hb->bytes));
+    memcpy(value->hb.bytes, hb->bytes, value->hb.len);
+}
+
+static
+void
+nci_core_param_set_li_a_hb(
+    NciCoreObject* core,
+    const NciCoreParamValue* value)
+{
+    nci_sm_set_li_a_hb(core->sm, &value->hb);
+}
+
+static
+void
+nci_core_param_reset_li_a_hb(
+    NciCoreObject* core)
+{
+    nci_sm_set_li_a_hb(core->sm, NULL);
 }
 
 static const NciCoreParamDesc nci_core_params[] = {
@@ -519,12 +562,19 @@ static const NciCoreParamDesc nci_core_params[] = {
         nci_core_param_set_la_nfcid1,
         nci_core_param_reset_la_nfcid1,
         nci_core_param_equal_nfcid
+    },{ /* NCI_CORE_PARAM_LI_A_HB */
+        "LI_A_HB",
+        nci_core_param_get_li_a_hb,
+        nci_core_param_set_li_a_hb,
+        nci_core_param_reset_li_a_hb,
+        nci_core_param_equal_hb
     }
 };
 
 G_STATIC_ASSERT(NCI_CORE_PARAM_LLC_VERSION == 0);
 G_STATIC_ASSERT(NCI_CORE_PARAM_LLC_WKS == 1);
 G_STATIC_ASSERT(NCI_CORE_PARAM_LA_NFCID1 == 2);
+G_STATIC_ASSERT(NCI_CORE_PARAM_LI_A_HB == 3);
 G_STATIC_ASSERT(NCI_CORE_PARAM_COUNT == G_N_ELEMENTS(nci_core_params));
 
 /*==========================================================================*

--- a/src/nci_sm.h
+++ b/src/nci_sm.h
@@ -68,6 +68,7 @@ struct nci_sm {
     guint8 llc_version;
     guint16 llc_wks;
     NciNfcid1 la_nfcid1; /* NFCID1 in Listen A mode */
+    NciAtsHb li_a_hb; /* ATS Historical Bytes in Listen A mode */
 };
 
 typedef
@@ -140,6 +141,12 @@ void
 nci_sm_set_la_nfcid1(
     NciSm* sm,
     const NciNfcid1* nfcid1)
+    NCI_INTERNAL;
+
+void
+nci_sm_set_li_a_hb(
+    NciSm* sm,
+    const NciAtsHb* hb)
     NCI_INTERNAL;
 
 void

--- a/src/nci_types_p.h
+++ b/src/nci_types_p.h
@@ -267,8 +267,8 @@ typedef enum nci_rf_technology {
 
 /* Listen Mode: ISO-DEP Discovery Parameters */
 #define NCI_CONFIG_LI_FWI                       (0x58)
-#define NCI_CONFIG_LA_HIST_BY                   (0x59)
-#define NCI_CONFIG_LB_H_INFO_RESP               (0x5A)
+#define NCI_CONFIG_LI_A_HIST_BY                 (0x59)
+#define NCI_CONFIG_LI_B_H_INFO_RESP             (0x5A)
 #define NCI_CONFIG_LI_BIT_RATE                  (0x5B)
 #define NCI_CONFIG_LI_A_RATS_TC1                (0x5C) /* NCI 2.0 */
 

--- a/src/nci_util.c
+++ b/src/nci_util.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2024 Slava Monich <slava@monich.com>
+ * Copyright (C) 2019-2025 Slava Monich <slava@monich.com>
  * Copyright (C) 2019-2021 Jolla Ltd.
  * Copyright (C) 2020 Open Mobile Platform LLC.
  *
@@ -104,7 +104,6 @@ nci_listen_mode(
     return FALSE;
 }
 
-static
 gboolean
 nci_parse_find_config_param(
     guint nparams,

--- a/src/nci_util_p.h
+++ b/src/nci_util_p.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2024 Slava Monich <slava@monich.com>
+ * Copyright (C) 2019-2025 Slava Monich <slava@monich.com>
  * Copyright (C) 2019-2021 Jolla Ltd.
  * Copyright (C) 2020 Open Mobile Platform LLC.
  *
@@ -63,6 +63,14 @@ nci_nfcid1_equal(
 gboolean
 nci_listen_mode(
     NCI_MODE mode)
+    NCI_INTERNAL;
+
+gboolean
+nci_parse_find_config_param(
+    guint nparams,
+    const GUtilData* params,
+    guint8 id,
+    GUtilData* value)
     NCI_INTERNAL;
 
 guint

--- a/unit/nci_core/test_nci_core.c
+++ b/unit/nci_core/test_nci_core.c
@@ -58,6 +58,7 @@ static TestOpt test_opt;
 #define CONFIG_SECTION "[Configuration]"
 #define CONFIG_ENTRY_TECHNOLOGIES "Technologies"
 #define CONFIG_ENTRY_LA_NFCID1 "LA_NFCID1"
+#define CONFIG_ENTRY_LI_A_HB "LI_A_HB"
 
 static const guint8 CORE_RESET_CMD[] = {
     0x20, 0x00, 0x01, 0x00
@@ -196,18 +197,19 @@ static const guint8 CORE_SET_CONFIG_RSP_ERROR[] = {
     0x40, 0x02, 0x02, NCI_STATUS_REJECTED, 0x00
 };
 static const guint8 CORE_GET_CONFIG_CMD_DISCOVERY[] = {
-    /* LA_SENS_RES_1, LA_NFCID1, LA_SEL_INFO, LF_PROTOCOL_TYPE */
-    0x20, 0x03, 0x05, 0x04, 0x30, 0x33, 0x32, 0x50
+    /* LA_SENS_RES_1, LA_SEL_INFO, LA_NFCID1, LF_PROTOCOL_TYPE, LI_A_HIST_BY */
+    0x20, 0x03, 0x06, 0x05, 0x30, 0x32, 0x33, 0x50, 0x59 
 };
 static const guint8 CORE_GET_CONFIG_RSP_DISCOVERY_INVALID_PARAM[] = {
     0x40, 0x03, 0x06, NCI_STATUS_INVALID_PARAM, 0x02,
     0x32, 0x00, 0x50, 0x00
 };
 static const guint8 CORE_GET_CONFIG_RSP_NO_LA_SENS_RES_1[] = {
-    0x40, 0x03, 0x0e, 0x00, 0x04,
-    0x33, 0x04, 0x08, 0x00, 0x00, 0x00, /* LA_NFCID1 (dynamic) */
+    0x40, 0x03, 0x10, 0x00, 0x04,
     0x32, 0x01, 0x00, /* LA_SEL_INFO = 0 */
-    0x50, 0x01, 0x00  /* LF_PROTOCOL_TYPE = 0 */
+    0x33, 0x04, 0x08, 0x00, 0x00, 0x00, /* LA_NFCID1 (dynamic) */
+    0x50, 0x01, 0x00, /* LF_PROTOCOL_TYPE = 0 */
+    0x59, 0x00        /* LI_A_HIST_BY (none) */
 };
 static const guint8 CORE_GET_CONFIG_RSP_NFCID_01020304050607[] = {
     0x40, 0x03, 0x14, 0x00, 0x04,
@@ -255,11 +257,12 @@ static const guint8 CORE_GET_CONFIG_RSP_ERROR[] = {
     0x40, 0x03, 0x02, 0x03, 0x00
 };
 static const guint8 CORE_SET_CONFIG_CMD_DISCOVERY_RW_FULL[] = {
-    0x20, 0x02, 0x10, 0x04,
+    0x20, 0x02, 0x12, 0x05,
     0x30, 0x01, 0x00, /* LA_SENS_RES_1 (4 bytes NFCID1) */
-    0x33, 0x04, 0x08, 0x00, 0x00, 0x00, /* LA_NFCID1 (dynamic) */
     0x32, 0x01, 0x00, /* LA_SEL_INFO = 0 */
-    0x50, 0x01, 0x00  /* LF_PROTOCOL_TYPE = 0 */
+    0x33, 0x04, 0x08, 0x00, 0x00, 0x00, /* LA_NFCID1 (dynamic) */
+    0x50, 0x01, 0x00, /* LF_PROTOCOL_TYPE = 0 */
+    0x59, 0x00        /* LI_A_HIST_BY (none) */
 };
 static const guint8 CORE_SET_CONFIG_CMD_DISCOVERY_RW[] = {
     0x20, 0x02, 0x07, 0x02,
@@ -278,20 +281,26 @@ static const guint8 CORE_SET_CONFIG_CMD_DISCOVERY_CE[] = {
 static const guint8 CORE_SET_CONFIG_CMD_NFCID_01020304050607_1[] = {
     0x20, 0x02, 0x10, 0x03,
     0x30, 0x01, 0x40, /* Default LA_SENS_RES_1 for 7 bytes NFCID1 */
-    0x33, 0x07, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, /* LA_NFCID1 */
-    0x32, 0x01, 0x20  /* LA_SEL_INFO = 0x20 */
+    0x32, 0x01, 0x20, /* LA_SEL_INFO = 0x20 */
+    0x33, 0x07, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07 /* LA_NFCID1 */
 };
 static const guint8 CORE_SET_CONFIG_CMD_NFCID_01020304050607_2[] = {
     0x20, 0x02, 0x10, 0x03,
     0x30, 0x01, 0x44, /* LA_SENS_RES_1 (7 bytes NFCID1) */
-    0x33, 0x07, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, /* LA_NFCID1 */
-    0x32, 0x01, 0x20  /* LA_SEL_INFO = 0x20 */
+    0x32, 0x01, 0x20, /* LA_SEL_INFO = 0x20 */
+    0x33, 0x07, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07 /* LA_NFCID1 */
 };
 static const guint8 CORE_SET_CONFIG_CMD_NFCID_DYNAMIC[] = {
     0x20, 0x02, 0x0d, 0x03,
     0x30, 0x01, 0x04, /* LA_SENS_RES_1 for dynamic 4 bytes NFCID1 */
-    0x33, 0x04, 0x08, 0x00, 0x00, 0x00, /* LA_NFCID1 (dynamic) */
-    0x32, 0x01, 0x20  /* LA_SEL_INFO = 0x20 */
+    0x32, 0x01, 0x20, /* LA_SEL_INFO = 0x20 */
+    0x33, 0x04, 0x08, 0x00, 0x00, 0x00 /* LA_NFCID1 (dynamic) */
+};
+static const guint8 CORE_SET_CONFIG_CMD_LI_A_HB_01020304[] = {
+    0x20, 0x02, 0x0d, 0x03,
+    0x30, 0x01, 0x00, /* LA_SENS_RES_1 (4 bytes NFCID1) */
+    0x32, 0x01, 0x20, /* LA_SEL_INFO = 0x20 */
+    0x59, 0x04, 0x01, 0x02, 0x03, 0x04  /* LI_A_HIST_BY (01020304) */
 };
 static const guint8 RF_SET_LISTEN_MODE_ROUTING_CMD_MIXED_RW_PEER[] = {
     0x21, 0x01, 0x1b, 0x00, 0x05,
@@ -1994,6 +2003,13 @@ static const NciCoreParam TEST_PARAM_LA_NFCID_01020304050607 = {
 };
 static const NciCoreParam* const TEST_PARAMS_LA_NFCID_01020304050607[] = {
     &TEST_PARAM_LA_NFCID_01020304050607, NULL
+};
+static const NciCoreParam TEST_PARAM_LI_A_HB_01020304 = {
+    .key = NCI_CORE_PARAM_LI_A_HB,
+    .value.hb = { 4, { 0x01, 0x02, 0x03, 0x04 } }
+};
+static const NciCoreParam* const TEST_PARAMS_LI_A_HB_01020304[] = {
+    &TEST_PARAM_LI_A_HB_01020304, NULL
 };
 
 static const TestSmEntry test_nci_sm_init_params[] = {
@@ -3936,6 +3952,39 @@ static const TestSmEntry test_nci_param_la_nfcid1[] = {
     TEST_NCI_SM_END()
 };
 
+/* Common part of LI_A_HB tests */
+#define TEST_NCI_PARAM_LI_A() \
+    TEST_NCI_SM_SET_OP_MODE(NFC_OP_MODE_CE), \
+    TEST_NCI_SM_SET_STATE(NCI_RFST_DISCOVERY), \
+    TEST_NCI_SM_ASSERT_STATES(NCI_STATE_INIT, NCI_RFST_DISCOVERY), \
+    TEST_NCI_DEFAULT_RESET_V2(), \
+    \
+    TEST_NCI_SM_ASSERT_STATES(NCI_RFST_IDLE, NCI_RFST_DISCOVERY), \
+    TEST_NCI_SM_EXPECT_CMD(CORE_GET_CONFIG_CMD_DISCOVERY), \
+    TEST_NCI_SM_QUEUE_RSP(CORE_GET_CONFIG_RSP_NO_LA_SENS_RES_1), \
+    TEST_NCI_SM_EXPECT_CMD(CORE_SET_CONFIG_CMD_LI_A_HB_01020304), \
+    TEST_NCI_SM_QUEUE_RSP(CORE_SET_CONFIG_RSP), \
+    TEST_NCI_SM_EXPECT_CMD(RF_SET_LISTEN_MODE_ROUTING_CMD_MIXED_CE_B_A), \
+    TEST_NCI_SM_QUEUE_RSP(RF_SET_LISTEN_MODE_ROUTING_RSP), \
+    \
+    TEST_NCI_SM_EXPECT_CMD(RF_DISCOVER_MAP_CMD_LISTEN_ISODEP), \
+    TEST_NCI_SM_QUEUE_RSP(RF_DISCOVER_MAP_RSP), \
+    TEST_NCI_SM_EXPECT_CMD(RF_DISCOVER_CMD_A_B_LISTEN), \
+    TEST_NCI_SM_QUEUE_RSP(RF_DISCOVER_RSP), \
+    \
+    TEST_NCI_SM_WAIT_STATE(NCI_RFST_DISCOVERY)
+
+static const TestSmEntry test_nci_param_li_a_hb[] = {
+    TEST_NCI_SM_SET_PARAMS(TEST_PARAMS_LI_A_HB_01020304, FALSE),
+    TEST_NCI_PARAM_LI_A(),
+    TEST_NCI_SM_END()
+};
+
+static const TestSmEntry test_nci_param_li_a_hb_conf[] = {
+    TEST_NCI_PARAM_LI_A(),
+    TEST_NCI_SM_END()
+};
+
 static const TestSmEntry test_nci_config_abf[] = {
     TEST_NCI_SM_SET_OP_MODE(NFC_OP_MODE_RW|NFC_OP_MODE_PEER|NFC_OP_MODE_CE|
                             NFC_OP_MODE_POLL|NFC_OP_MODE_LISTEN),
@@ -4114,7 +4163,8 @@ static const char test_nci_config_ab_invalid_la_nfcid1_data1[] =
 static const char test_nci_config_ab_invalid_la_nfcid1_data2[] =
     CONFIG_SECTION "\n"
     CONFIG_ENTRY_TECHNOLOGIES " = A,B\n"
-    CONFIG_ENTRY_LA_NFCID1 " = Garbage!\n";
+    CONFIG_ENTRY_LA_NFCID1 " = Garbage!\n"
+    CONFIG_ENTRY_LI_A_HB " = Junk!\n";
 static const char test_nci_config_la_nfcid1_data[] =
     CONFIG_SECTION "\n"
     CONFIG_ENTRY_TECHNOLOGIES " = A,B\n"
@@ -4123,6 +4173,10 @@ static const char test_nci_config_la_nfcid1_dynamic_data[] =
     CONFIG_SECTION "\n"
     CONFIG_ENTRY_TECHNOLOGIES " = A,B\n"
     CONFIG_ENTRY_LA_NFCID1 " = \n";
+static const char test_nci_config_li_a_hb_data[] =
+    CONFIG_SECTION "\n"
+    CONFIG_ENTRY_TECHNOLOGIES " = A,B\n"
+    CONFIG_ENTRY_LI_A_HB " = 01020304\n";
 
 static const TestNciSmData nci_sm_tests[] = {
     { "init-ok", test_nci_sm_init_ok },
@@ -4209,6 +4263,9 @@ static const TestNciSmData nci_sm_tests[] = {
     { "read-ce-ndef-ab-invalid_la_nfcid1_config2", test_nci_sm_read_ce_ndef_ab,
        test_nci_config_ab_invalid_la_nfcid1_data2 },
     { "param_la_nfcid1", test_nci_param_la_nfcid1, test_nci_config_ab_data },
+    { "param_li_a_hb", test_nci_param_li_a_hb },
+    { "param_li_a_hb_conf", test_nci_param_li_a_hb_conf,
+       test_nci_config_li_a_hb_data },
     { "config_default", test_nci_config_abf, test_nci_config_ab_data_default },
     { "config_empty", test_nci_config_abf, test_nci_config_ab_data_empty },
     { "config_junk", test_nci_config_abf, test_nci_config_ab_data_junk },


### PR DESCRIPTION
It may be required for proper emulation of certain Type 4A cards.