### PR TITLE
Accept CORE_INIT_RSP (v2) with RF interface extensions

### DIFF
--- a/src/nci_transition_reset.c
+++ b/src/nci_transition_reset.c
@@ -381,7 +381,7 @@ nci_transition_reset_init_v2_rsp(
          * +=========================================================+
          */
         if (len >= 14 && pkt[0] == NCI_STATUS_OK &&
-            len == (2 * (n = pkt[13]) + 14)) {
+            len >= (2 * (n = pkt[13]) + 14)) {
             guint8 max_logical_conns = pkt[5];
             guint8 max_control_payload = pkt[8];
             guint i;
@@ -439,7 +439,7 @@ nci_transition_reset_init_v2_rsp(
             nci_transition_reset_set_config(self);
             return;
         }
-        GWARN("CORE_INIT (v1) failed (or is incomprehensible)");
+        GWARN("CORE_INIT (v2) failed (or is incomprehensible)");
     }
     nci_sm_error(sm);
 }

--- a/unit/nci_core/test_nci_core.c
+++ b/unit/nci_core/test_nci_core.c
@@ -109,6 +109,12 @@ static const guint8 CORE_INIT_V2_RSP[] = {
     0x05, 0x01, 0x00, 0x02, 0x00, 0x03, 0x00, 0x00,
     0x00, 0x90, 0x00
 };
+static const guint8 CORE_INIT_V2_RSP_EXT[] = {
+    0x40, 0x01, 0x1a, 0x00, 0x1a, 0x7e, 0x06, 0x00,
+    0x02, 0x00, 0x02, 0xff, 0xff, 0x00, 0x0c, 0x01,
+    0x05, 0x01, 0x01, 0x02, 0x02, 0x01, 0x02, 0x03,
+    0x00, 0x00, 0x00, 0x90, 0x00
+};
 static const guint8 CORE_INIT_V2_RSP_NO_PROTOCOL_ROUTING[] = {
     0x40, 0x01, 0x18, 0x00, 0x1a, 0x7a, 0x06, 0x00,
     0x02, 0x00, 0x02, 0xff, 0xff, 0x00, 0x0c, 0x01,
@@ -2171,6 +2177,19 @@ static const TestSmEntry test_nci_sm_init_v2[] = {
     TEST_NCI_SM_QUEUE_NTF(CORE_RESET_V2_NTF),
     TEST_NCI_SM_EXPECT_CMD(CORE_INIT_CMD_V2),
     TEST_NCI_SM_QUEUE_RSP(CORE_INIT_V2_RSP),
+    TEST_NCI_SM_EXPECT_CMD(CORE_SET_CONFIG_CMD_DEFAULT),
+    TEST_NCI_SM_QUEUE_RSP(CORE_SET_CONFIG_RSP),
+    TEST_NCI_SM_WAIT_STATE(NCI_RFST_IDLE),
+    TEST_NCI_SM_END()
+};
+
+static const TestSmEntry test_nci_sm_init_v2_ext[] = {
+    TEST_NCI_SM_EXPECT_CMD(CORE_RESET_CMD),
+    TEST_NCI_SM_SET_STATE(NCI_RFST_IDLE),
+    TEST_NCI_SM_QUEUE_RSP(CORE_RESET_V2_RSP),
+    TEST_NCI_SM_QUEUE_NTF(CORE_RESET_V2_NTF),
+    TEST_NCI_SM_EXPECT_CMD(CORE_INIT_CMD_V2),
+    TEST_NCI_SM_QUEUE_RSP(CORE_INIT_V2_RSP_EXT),
     TEST_NCI_SM_EXPECT_CMD(CORE_SET_CONFIG_CMD_DEFAULT),
     TEST_NCI_SM_QUEUE_RSP(CORE_SET_CONFIG_RSP),
     TEST_NCI_SM_WAIT_STATE(NCI_RFST_IDLE),
@@ -4257,6 +4276,7 @@ static const TestNciSmData nci_sm_tests[] = {
     { "reset-timeout", test_nci_sm_reset_timeout },
     { "inir-set-config-timeout", test_nci_sm_init_set_config_timeout },
     { "init-v2", test_nci_sm_init_v2 },
+    { "init-v2-ext", test_nci_sm_init_v2_ext },
     { "init-v2-error", test_nci_sm_init_v2_error },
     { "init-v2-broken1", test_nci_sm_init_v2_broken1 },
     { "init-v2-broken2", test_nci_sm_init_v2_broken2 },


### PR DESCRIPTION
ST54L (Volla Phone Plinius) reports one extension each for the Frame and ISO-DEP RF interfaces in CORE_INIT_RSP, so the entries are longer than 2 bytes and the response fails the exact length check in the v2 reset transition, leaving the state machine in ERROR. The parsing loop below the check already handles variable-length entries, so only require the minimum length. Also fixes the warning in the v2 handler saying "(v1)".

Response that triggered it (26-byte payload, the check expects 24):

```
40 01 1a 00 6a 7e 06 00 01 00 04 ff ff 01 0c 01
05 01 01 02 02 01 02 03 00 00 00 90 00
```

Verified on the device: with this change init completes and tags are read; added a unit test with the extension-carrying response.